### PR TITLE
Improving sessions logic and start conversation button

### DIFF
--- a/cypress/e2e/engagement.cy.ts
+++ b/cypress/e2e/engagement.cy.ts
@@ -79,6 +79,9 @@ describe("Engagement Message", () => {
 				unreadMessages: {
 					enablePreview: false,
 				},
+				homeScreen: {
+					enabled: false,
+			}
 			},
 		});
 		cy.get("[data-cognigy-webchat-toggle]").click().click();
@@ -137,6 +140,9 @@ describe("Engagement Message", () => {
 				unreadMessages: {
 					enablePreview: false,
 				},
+				homeScreen: {
+					enabled: false,
+			}
 			},
 		});
 		cy.wait(500);

--- a/src/common/interfaces/message.ts
+++ b/src/common/interfaces/message.ts
@@ -6,7 +6,7 @@ export interface IBaseMessage {
 	prevMessage?: IMessage;
 	source: string;
 	text?: string;
-	timestamp: number;
+	timestamp?: number;
 }
 
 export interface IUserMessage extends IBaseMessage {

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -741,6 +741,26 @@ export class WebchatUI extends React.PureComponent<
 				options,
 			});
 		} else {
+			this.props.onSwitchSession();
+			this.props.onSendMessage(text, data, options);
+		}
+	};
+
+	handleSendActionButtonMessageFromTeaser = (
+		text?: string,
+		data?: any,
+		options?: Partial<ISendMessageOptions>,
+	) => {
+		this.props.onSetShowHomeScreen(false);
+		this.props.onSetShowChatOptionsScreen(false);
+
+		if (this.props.config.settings.privacyNotice.enabled && !this.props.hasAcceptedTerms) {
+			this.props.onSetStoredMessage({
+				text,
+				data,
+				options,
+			});
+		} else {
 			this.props.onShowChatScreen();
 			this.props.onSendMessage(text, data, options);
 		}
@@ -960,7 +980,7 @@ export class WebchatUI extends React.PureComponent<
 													config={config}
 													onEmitAnalytics={onEmitAnalytics}
 													onSendActionButtonMessage={
-														this.handleSendActionButtonMessage
+														this.handleSendActionButtonMessageFromTeaser
 													}
 													onHideTeaserMessage={onHideTeaserMessage}
 													wasOpen={wasOpen}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1030,6 +1030,7 @@ export class WebchatUI extends React.PureComponent<
 			requestRatingEventBannerText,
 			showRatingScreen,
 			onShowRatingScreen,
+			onShowChatScreen,
 			onSwitchSession,
 			onClose,
 			onEmitAnalytics,
@@ -1110,6 +1111,7 @@ export class WebchatUI extends React.PureComponent<
 				},
 			};
 
+			onShowChatScreen();
 			this.props.onSendMessage("", data);
 		};
 

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -766,9 +766,16 @@ export class WebchatUI extends React.PureComponent<
 	}
 
 	openConversationFromTeaser = () => {
-		// in this case we always open to current session
 		this.props.onToggle();
-		this.handleStartConversation();
+		this.props.onSetShowHomeScreen(false);
+		this.props.onSetShowChatOptionsScreen(false);
+
+		const showPrivacyScreen = this.props.config.settings.privacyNotice.enabled && !this.props.hasAcceptedTerms;
+		if (showPrivacyScreen) {
+			this.setState({ lastUnseenMessageText: "" });
+		} else {
+			this.props.onShowChatScreen();
+		}
 	};
 
 	render() {

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1104,14 +1104,13 @@ export class WebchatUI extends React.PureComponent<
 
 		const handleAcceptTerms = () => {
 			onAcceptTerms(this.props?.options?.userId || "");
+			onShowChatScreen();
 
 			const data = {
 				_cognigy: {
 					controlCommands: [{ type: "acceptPrivacyPolicy" }],
 				},
 			};
-
-			onShowChatScreen();
 			this.props.onSendMessage("", data);
 		};
 

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -760,7 +760,9 @@ export class WebchatUI extends React.PureComponent<
 		this.props.onToggle();
 
 		const homeScreenEnabled = this.props.config.settings.homeScreen.enabled === true;
-		if (!homeScreenEnabled) {
+		if (homeScreenEnabled) {
+			this.setState({ lastUnseenMessageText: "" });
+		} else {
 			this.handleStartConversation();
 		}
 	}

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -248,7 +248,7 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 				>
 					{homeScreen.welcomeText || "Welcome to the Cognigy Webchat"}
 				</HomeScreenTitle>
-				{config.settings.homeScreen.conversationStarters.enabled && (
+				{homeScreen?.conversationStarters?.enabled && (
 					<HomeScreenButtons className="webchat-homescreen-buttons">
 						<ActionButtons
 							size="large"

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -210,8 +210,12 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 	}, [showHomeScreen]);
 
 	return (
-		<HomeScreenRoot className="webchat-homescreen-root" aria-hidden={!showHomeScreen} ref={homeScreenRef}>
-			<h2 className="sr-only">Home Screen</h2> 
+		<HomeScreenRoot
+			className="webchat-homescreen-root"
+			aria-hidden={!showHomeScreen}
+			ref={homeScreenRef}
+		>
+			<h2 className="sr-only">Home Screen</h2>
 			<HomeScreenContent className="webchat-homescreen-content" settings={config?.settings}>
 				<HomeScreenHeader className="webchat-homescreen-header">
 					{config?.settings?.layout?.logoUrl ? (
@@ -244,18 +248,20 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 				>
 					{homeScreen.welcomeText || "Welcome to the Cognigy Webchat"}
 				</HomeScreenTitle>
-				<HomeScreenButtons className="webchat-homescreen-buttons">
-					<ActionButtons
-						size="large"
-						showUrlIcon
-						buttonClassName="webchat-homescreen-button"
-						containerClassName="webchat-homescreen-button-container"
-						payload={buttons}
-						config={config}
-						action={showHomeScreen ? onSendActionButtonMessage : undefined}
-						onEmitAnalytics={onEmitAnalytics}
-					/>
-				</HomeScreenButtons>
+				{config.settings.homeScreen.conversationStarters.enabled && (
+					<HomeScreenButtons className="webchat-homescreen-buttons">
+						<ActionButtons
+							size="large"
+							showUrlIcon
+							buttonClassName="webchat-homescreen-button"
+							containerClassName="webchat-homescreen-button-container"
+							payload={buttons}
+							config={config}
+							action={showHomeScreen ? onSendActionButtonMessage : undefined}
+							onEmitAnalytics={onEmitAnalytics}
+						/>
+					</HomeScreenButtons>
+				)}
 			</HomeScreenContent>
 			<HomeScreenActions className="webchat-homescreen-actions">
 				<StartButton

--- a/src/webchat-ui/components/presentational/TeaserMessage.tsx
+++ b/src/webchat-ui/components/presentational/TeaserMessage.tsx
@@ -88,7 +88,9 @@ export const TeaserMessage = (props: ITeaserMessageProps) => {
 		wasOpen,
 	} = props;
 
-	const buttons: IWebchatButton[] = config.settings.teaserMessage.conversationStarters.starters;
+	const { teaserMessage } = config.settings;
+
+	const buttons: IWebchatButton[] = teaserMessage.conversationStarters.starters;
 
 	const isDesktopMedia = useMediaQuery({ query: "(min-width: 576px)" });
 
@@ -155,7 +157,7 @@ export const TeaserMessage = (props: ITeaserMessageProps) => {
 					{messageText}
 				</Typography>
 			</UnreadMessagePreview>
-			{!wasOpen && (
+			{!wasOpen && teaserMessage?.conversationStarters?.enabled && (
 				<ButtonContainer className="webchat-teaser-message-action-buttons">
 					<ActionButtons
 						showUrlIcon

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -55,13 +55,14 @@ const StartButton = styled(PrimaryButton)(() => ({
 
 interface IPrevConversationsListProps {
 	config: IWebchatConfig;
+	currentSession?: string;
 	conversations: PrevConversationsState;
 	onSetShowPrevConversations: (show: boolean) => void;
 	onSwitchSession: (sessionId?: string, conversation?: PrevConversationsState[string]) => void;
 }
 
 export const PrevConversationsList = (props: IPrevConversationsListProps) => {
-	const { conversations, config, onSetShowPrevConversations, onSwitchSession } = props;
+	const { conversations, config, onSetShowPrevConversations, onSwitchSession, currentSession } = props;
 
 	// we sort the conversation based on last message timestamp
 	// result: the last updated conversation goes on top
@@ -91,7 +92,10 @@ export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 
 	const switchSession = useCallback(
 		(sessionId?: string, conversation?: PrevConversationsState[string]) => {
-			onSwitchSession(sessionId, conversation);
+			if (sessionId && sessionId !== currentSession) {
+				console.log(sessionId, currentSession);
+				onSwitchSession(sessionId, conversation);
+			}
 			onSetShowPrevConversations(false);
 		},
 		[],

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -93,7 +93,6 @@ export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 	const switchSession = useCallback(
 		(sessionId?: string, conversation?: PrevConversationsState[string]) => {
 			if (sessionId && sessionId !== currentSession) {
-				console.log(sessionId, currentSession);
 				onSwitchSession(sessionId, conversation);
 			}
 			onSetShowPrevConversations(false);

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsListItem.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsListItem.tsx
@@ -7,6 +7,7 @@ import { getAvatars, getLastMessagePreview, getParticipants, getRelativeTime } f
 import { IWebchatConfig } from "../../../../common/interfaces/webchat-config";
 import { PrevConversationsState } from "../../../../webchat/store/previous-conversations/previous-conversations-reducer";
 import { Typography } from "@cognigy/chat-components";
+import { IMessage } from "../../../../common/interfaces/message";
 
 const ListItem = styled.div(({ theme }) => ({
 	display: "flex",
@@ -101,7 +102,9 @@ interface IConversationsListItemProps {
 export const ConversationsListItem = (props: IConversationsListItemProps) => {
 	const { sessionId, conversation, config, index, switchSession } = props;
 
-	const avatars = getAvatars(conversation.messages);
+	const messages = conversation.messages as IMessage[]
+
+	const avatars = getAvatars(messages);
 
 	const handleClick = () => {
 		switchSession(sessionId, conversation);
@@ -136,12 +139,12 @@ export const ConversationsListItem = (props: IConversationsListItemProps) => {
 			</Left>
 			<Center>
 				<CenterTitle variant="body-regular" component="div">
-					{getLastMessagePreview(conversation.messages)}
+					{getLastMessagePreview(messages)}
 				</CenterTitle>
 				<CenterMeta variant="title2-regular" component="div">
-					<MetaNames>{getParticipants(conversation.messages, config)}</MetaNames>
+					<MetaNames>{getParticipants(messages, config)}</MetaNames>
 					<Ellipsis />
-					<MetaTime>{getRelativeTime(conversation.messages)}</MetaTime>
+					<MetaTime>{getRelativeTime(messages)}</MetaTime>
 				</CenterMeta>
 			</Center>
 			<Right>

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -2,7 +2,7 @@ import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
 import { sendMessage, triggerEngagementMessage } from '../store/messages/message-middleware';
-import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setScrollToPosition, setLastScrolledPosition, setShowHomeScreen, setShowPrevConversations, setShowChatOptionsScreen, setHasAcceptedTerms, UIState, setStoredMessage } from '../store/ui/ui-reducer';
+import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setScrollToPosition, setLastScrolledPosition, setShowHomeScreen, showChatScreen, setShowPrevConversations, setShowChatOptionsScreen, setHasAcceptedTerms, UIState, setStoredMessage } from '../store/ui/ui-reducer';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 import { connect as doConnect } from "../store/connection/connection-middleware";
 import { setHasGivenRating, showRatingScreen } from "../store/rating/rating-reducer";
@@ -79,6 +79,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         onSetShowHomeScreen: (show: boolean) => dispatch(setShowHomeScreen(show)),
         onSetShowPrevConversations: (show: boolean) => dispatch(setShowPrevConversations(show)),
         onSetShowChatOptionsScreen: (show: boolean) => dispatch(setShowChatOptionsScreen(show)),
+        onShowChatScreen: () => dispatch(showChatScreen()),
         onSwitchSession: (sessionId?: string, conversation?: PrevConversationsState[string]) => dispatch(switchSession(sessionId, conversation)),
         onAcceptTerms: (userId: string) => dispatch(setHasAcceptedTerms(userId)),
         onSetStoredMessage: (message: UIState['storedMessage']) => dispatch(setStoredMessage(message)),

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -22,6 +22,7 @@ import { isDisabledDueToConnectivity } from '../helper/connectivity';
 import { createNotification } from '../../webchat-ui/components/presentational/Notifications';
 import { getStorage } from '../helper/storage';
 import { hasAcceptedTermsInStorage } from '../helper/privacyPolicy';
+import { setUserId } from '../store/options/options-reducer';
 
 export interface WebchatProps extends FromProps {
     url: string;
@@ -72,6 +73,9 @@ export class Webchat extends React.PureComponent<WebchatProps> {
         this.store.dispatch(loadConfig());
         if (this.props.options?.sessionId) {
             this.store.dispatch(setInitialSessionId(this.props.options.sessionId));
+        }
+        if (this.props.options?.userId) {
+            this.store.dispatch(setUserId(this.props.options?.userId));
         }
     }
 

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -6,7 +6,7 @@ import { ConnectedWebchatUI, FromProps } from './ConnectedWebchatUI';
 import { MessagePlugin } from '../../common/interfaces/message-plugin';
 import { sendMessage } from '../store/messages/message-middleware';
 import { MessageSender } from '../../webchat-ui/interfaces';
-import { setHasAcceptedTerms, setOpen, setShowHomeScreen, toggleOpen } from '../store/ui/ui-reducer';
+import { setHasAcceptedTerms, setOpen, setShowHomeScreen, showChatScreen, toggleOpen } from '../store/ui/ui-reducer';
 import { loadConfig } from '../store/config/config-middleware';
 import { connect } from '../store/connection/connection-middleware';
 import { EventEmitter } from 'events';
@@ -139,7 +139,8 @@ export class Webchat extends React.PureComponent<WebchatProps> {
     }
 
     startConversation = () => {
-       this.store.dispatch(setShowHomeScreen(false));
+        this.store.dispatch(setShowHomeScreen(false));
+        this.store.dispatch(showChatScreen());
     }
 
     on = (event, handler) => {

--- a/src/webchat/helper/storage.ts
+++ b/src/webchat/helper/storage.ts
@@ -25,8 +25,8 @@ export const getAllConversations = (
 	currentURLtoken?: string,
 ) => {
 	return Object.keys(storage).reduce((acc, item) => {
-		// skip missing userId or sessionId
-		if (!currentSessionId || !currentUserId || !currentURLtoken) return acc;
+		// skip missing userId or URLtoken
+		if (!currentUserId || !currentURLtoken) return acc;
 
 		const data = storage.getItem(item) || "";
 

--- a/src/webchat/store/autoinject/autoinject-middleware.ts
+++ b/src/webchat/store/autoinject/autoinject-middleware.ts
@@ -9,18 +9,18 @@ export const createAutoInjectMiddleware = (webchat: Webchat): Middleware<unknown
     switch (action.type) {
         case 'SET_CONFIG':
         case 'SET_CONNECTED':
-        case 'SET_OPEN':
+        case 'SHOW_CHAT_SCREEN':
         case 'SET_OPTIONS': {
             const nextActionResult = next(action);
             
             (() => {
                 const state = api.getState();
-                const { isAutoInjectHandled: isAutoInjectTriggered, isConfiguredOnce, isConnectedOnce, isOpenedOnce, isSessionRestoredOnce } = state.autoInject;
+                const { isAutoInjectHandled: isAutoInjectTriggered, isConfiguredOnce, isConnectedOnce, isChatOpenedOnce, isSessionRestoredOnce } = state.autoInject;
                 
                 if (isAutoInjectTriggered)
                     return;
                 
-                if (!isConfiguredOnce || !isConnectedOnce || !isOpenedOnce || !isSessionRestoredOnce)
+                if (!isConfiguredOnce || !isConnectedOnce || !isChatOpenedOnce || !isSessionRestoredOnce)
                     return;
                 
                 api.dispatch(triggerAutoInject());

--- a/src/webchat/store/autoinject/autoinject-reducer.ts
+++ b/src/webchat/store/autoinject/autoinject-reducer.ts
@@ -2,10 +2,10 @@ import { Reducer } from "redux";
 import { SetConfigAction } from '../config/config-reducer';
 import { SetConnectedAction } from '../connection/connection-reducer';
 import { SetOptionsAction } from "../options/options-reducer";
-import { SetOpenAction } from '../ui/ui-reducer';
+import { ShowChatScreenAction } from '../ui/ui-reducer';
 
 const getInitialState = () => ({
-    isOpenedOnce: false,
+    isChatOpenedOnce: false,
     isConnectedOnce: false,
     isConfiguredOnce: false,
     isSessionRestoredOnce: false,
@@ -34,7 +34,7 @@ export type TAutoInjectResetAction = ReturnType<typeof autoInjectHandledReset>;
 
 export type TAutoInjectAction =
     | SetConnectedAction
-    | SetOpenAction
+    | ShowChatScreenAction
     | SetOptionsAction
     | SetConfigAction
     | TTriggerAutoInjectAction
@@ -59,11 +59,11 @@ export const autoInject: Reducer<TAutoInjectState, TAutoInjectAction> = (state =
             break;
         }
 
-        case 'SET_OPEN': {
-            if (action.open && !state.isOpenedOnce) {
+        case 'SHOW_CHAT_SCREEN': {
+            if (!state.isChatOpenedOnce) {
                 return {
                     ...state,
-                    isOpenedOnce: true
+                    isChatOpenedOnce: true
                 }
             }
 

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -66,14 +66,6 @@ export const createConnectionMiddleware = (client: SocketClient): Middleware<obj
             break;
         }
 
-        case "SET_HAS_ACCEPTED_TERMS": {
-            if (!client.connected) {
-                store.dispatch(connect(true));
-            }
-
-            break;
-        }
-
         case "SEND_MESSAGE": {
             store.dispatch(connect());
 

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -13,9 +13,8 @@ export interface ISendMessageOptions {
 }
 
 const CONNECT = 'CONNECT'
-export const connect = (termsAccepted?: boolean) => ({
-    type: CONNECT as 'CONNECT',
-    termsAccepted
+export const connect = () => ({
+    type: CONNECT as 'CONNECT'
 });
 export type ConnectAction = ReturnType<typeof connect>;
 

--- a/src/webchat/store/options/options-reducer.ts
+++ b/src/webchat/store/options/options-reducer.ts
@@ -16,13 +16,27 @@ export const setOptions = (options: Options) => ({
 });
 export type SetOptionsAction = ReturnType<typeof setOptions>;
 
-export const options: Reducer<OptionsState, SetOptionsAction> = (state = getInitialState(), action) => {
+const SET_USER_ID = 'SET_USER_ID';
+export const setUserId = (userId: string) => ({
+    type: SET_USER_ID as 'SET_USER_ID',
+    userId
+});
+export type SetUserIdAction = ReturnType<typeof setUserId>;
+
+export const options: Reducer<OptionsState, SetOptionsAction | SetUserIdAction> = (state = getInitialState(), action) => {
     switch (action.type) {
         case 'SET_OPTIONS': {
             return action.options;
-        };
+        }
+            
+        case 'SET_USER_ID': {
+            return {
+				...state,
+				userId: action.userId,
+			};
+        }
 
         default:
             return state;
-    };
+    }
 };

--- a/src/webchat/store/previous-conversations/previous-conversations-middleware.ts
+++ b/src/webchat/store/previous-conversations/previous-conversations-middleware.ts
@@ -8,6 +8,7 @@ import { SetPrevStateAction, setPrevState } from "../reducer";
 import { SocketClient } from "@cognigy/socket-client";
 import { autoInjectHandledReset, triggerAutoInject } from "../autoinject/autoinject-reducer";
 import { setConnecting } from "../connection/connection-reducer";
+import { setOptions } from "../options/options-reducer";
 
 const SWITCH_SESSION = "SWITCH_SESSION";
 export const switchSession = (
@@ -51,6 +52,7 @@ export const createPrevConversationsMiddleware =
 					.switchSession(targetSession)
 					.then(() => {
 						store.dispatch(setConnecting(false));
+						store.dispatch(setOptions(client.socketOptions));
 						store.dispatch(autoInjectHandledReset());
 						store.dispatch(triggerAutoInject());
 					})

--- a/src/webchat/store/ui/ui-middleware.ts
+++ b/src/webchat/store/ui/ui-middleware.ts
@@ -4,7 +4,7 @@ import { clearUnseenMessages } from "../unseen-messages/unseen-message-reducer";
 import {
 	setOpen,
 	ToggleOpenAction,
-	SetOpenAction,
+	ShowChatScreenAction,
 	SetPageVisibleAction,
 	SetHasAcceptedTermsAction,
 } from "./ui-reducer";
@@ -15,7 +15,7 @@ export const uiMiddleware: Middleware<object, StoreState> =
 	store =>
 	next =>
 	(
-		action: ToggleOpenAction | SetOpenAction | SetPageVisibleAction | SetHasAcceptedTermsAction,
+		action: ToggleOpenAction | ShowChatScreenAction | SetPageVisibleAction | SetHasAcceptedTermsAction,
 	) => {
 		const { disableLocalStorage, useSessionStorage } =
 			store.getState().config.settings.embeddingConfiguration;
@@ -30,9 +30,9 @@ export const uiMiddleware: Middleware<object, StoreState> =
 				break;
 			}
 
-			// if the webchat is opened while the page is active, reset unread messages
-			case "SET_OPEN": {
-				if (action.open && store.getState().ui.isPageVisible) {
+			// if the chat screen is opened while the page is active, reset unread messages
+			case "SHOW_CHAT_SCREEN": {
+				if (store.getState().ui.isPageVisible) {
 					store.dispatch(clearUnseenMessages());
 				}
 

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -58,6 +58,12 @@ export const setShowHomeScreen = (showHomeScreen: boolean) => ({
 });
 export type SetShowHomeScreenAction = ReturnType<typeof setShowHomeScreen>;
 
+export const SHOW_CHAT_SCREEN = 'SHOW_CHAT_SCREEN';
+export const showChatScreen = () => ({
+    type: SHOW_CHAT_SCREEN as 'SHOW_CHAT_SCREEN'
+});
+export type ShowChatScreenAction = ReturnType<typeof showChatScreen>;
+
 export const SET_SHOW_PREV_CONVERSATIONS = 'SET_SHOW_PREV_CONVERSATIONS';
 export const setShowPrevConversations = (showPrevConversations: boolean) => ({
     type: SET_SHOW_PREV_CONVERSATIONS as 'SET_SHOW_PREV_CONVERSATIONS',


### PR DESCRIPTION
# Success criteria

- This PR improves the behavior of the Start Conversation buttons, in Home Screen. The goal is to prevent the creation of new session on every button click. If a session is already active, it opens to that session. 
- It was refactored the logic regarding the socket connection, in case of Home Screen active.
- We now connect to the socket only if the user hit the Start Conversation button from home or from teaser messages or from Previous conversation.
- It fixes a bug where Conversation starters button in Home Page and Teaser message, in case are disabled and some button is configured, it displays anyway on UI.

# How to test
Test a new endpoint with all different configurations, with and without persistent userId / sessionId
1. Basic config without Home Screen, Privacy Screen or teaser message.
2. Config with Homepage active and/or Privacy Screen active
3. With action button in Home screen and/or in Teaser message and preview messages