### PR TITLE
Feature/75532 image in quick reply

### DIFF
--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -733,6 +733,14 @@ This is the style of the single Quick Reply element, all of them will be modifie
 }
 
 ```
+* *webchat-template-button-image*  
+This class modifies the style of the images inside the quick reply buttons. The default border-top-leftr-radius and border-bottom-left-radius of the images inside the button is 19px. You can override that with the help of this class.
+```CSS
+[data-cognigy-webchat-root] .webchat-quick-reply-template-replies-container .webchat-template-button-image {
+    background-color: black;
+    border-radius: 10px;
+}
+```
 
 ### Buttons
 

--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -734,7 +734,7 @@ This is the style of the single Quick Reply element, all of them will be modifie
 
 ```
 * *webchat-template-button-image*  
-This class modifies the style of the images inside the quick reply buttons. The default border-top-leftr-radius and border-bottom-left-radius of the images inside the button is 19px. You can override that with the help of this class.
+This class modifies the style of the images inside the quick reply buttons. The default border-top-left-radius and border-bottom-left-radius of the images inside the button is 19px. You can override that with the help of this class.
 ```CSS
 [data-cognigy-webchat-root] .webchat-quick-reply-template-replies-container .webchat-template-button-image {
     background-color: black;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",
-				"@cognigy/chat-components": "0.36.1",
+				"@cognigy/chat-components": "0.37.0",
 				"@cognigy/socket-client": "5.0.0-beta.21",
 				"@emotion/cache": "^10.0.29",
 				"@emotion/react": "^11.13.0",
@@ -828,9 +828,9 @@
 			}
 		},
 		"node_modules/@cognigy/chat-components": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.36.1.tgz",
-			"integrity": "sha512-2XJCchzlt2Z2CO6WVOCc3yoqxRpP0Rm70uW56xfPoiWqOoAHK5BBHgh9H27pxzfqDSH7oAI50qWBlG3oJCBtmg==",
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.37.0.tgz",
+			"integrity": "sha512-vjE1Q6DNVF48nqjjNl0D1W9dJgVUIHAu9wEI+Ycgf9qjjWZA6eqvon88oxmQ6xX+q48dIgZ+RNsfJK2xK5NBiQ==",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"@braintree/sanitize-url": "^6.0.0",
-		"@cognigy/chat-components": "0.36.1",
+		"@cognigy/chat-components": "0.37.0",
 		"@cognigy/socket-client": "5.0.0-beta.21",
 		"@emotion/cache": "^10.0.29",
 		"@emotion/react": "^11.13.0",

--- a/src/webchat-ui/utils/normalize.css
+++ b/src/webchat-ui/utils/normalize.css
@@ -82,7 +82,7 @@
   margin: 0;
 }
 
-[data-cognigy-webchat-root] button, [data-cognigy-webchat-root] input {
+[data-cognigy-webchat-root] input {
   overflow: visible;
 }
 

--- a/src/webchat-ui/utils/normalize.css
+++ b/src/webchat-ui/utils/normalize.css
@@ -82,7 +82,7 @@
   margin: 0;
 }
 
-[data-cognigy-webchat-root] input {
+[data-cognigy-webchat-root] button, [data-cognigy-webchat-root] input {
   overflow: visible;
 }
 


### PR DESCRIPTION
# Success criteria
Please describe what should be possible after this change. List all individual items on a separate line.

- Add documentation for the new quick reply image class
- Update chat-components to 0.37.0

# How to test
Please describe the individual steps on how a peer can test your change.

1. See if the added class is in the document preview
2. To test the chat-components update, create a flow which has a say node of output type quick reply. Add a quick reply button with image. Now create webchat 3 endpoint that uses this flow. In index.html, replace the endpoint URL with yours and test it locally. The image you added in the quick reply button should be visible in the webchat locally

