### PR TITLE
Add possibility to customize watermark Url

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -107,6 +107,7 @@ See it in action:
 | disableUrlButtonSanitization | boolean | `false` | By default, 'JavaScript URLs' starting with javascript: will get removed. |
 | watermark | string | `"default"` | Allowed values: `"default" \| "custom" \| "none"` |
 | watermarkText | string | `"Powered by Cognigy.AI"` | This will be used if watermark is set to custom |
+| watermarkUrl | string | `""` | URL to which the watermark links if a custom watermark is set. | 
 
 #### Colors
 | Name | Type | Default | Description |
@@ -374,6 +375,7 @@ interface IWebchatSettings {
 		disableUrlButtonSanitization: boolean;
 		watermark: "default" | "custom" | "none";
 		watermarkText: string;
+		watermarkUrl: string;
 	};
 	colors: {
 		primaryColor: string;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -139,6 +139,7 @@ export interface IWebchatSettings {
 		disableUrlButtonSanitization: boolean;
 		watermark: "default" | "custom" | "none";
 		watermarkText: string;
+		watermarkUrl: string;
 	};
 	colors: {
 		primaryColor: string;

--- a/src/webchat-ui/components/branding/Branding.tsx
+++ b/src/webchat-ui/components/branding/Branding.tsx
@@ -34,10 +34,11 @@ interface IBrandingProps {
 	id?: string;
 	watermark?: IWebchatSettings["layout"]["watermark"];
 	watermarkText?: string;
+	watermarkUrl?: string;
 }
 
 const Branding: FC<IBrandingProps> = (props) => {
-	const { id, watermark, watermarkText } = props;
+	const { id, watermark, watermarkText, watermarkUrl } = props;
 
 	if (watermark === "none") return (
 		<Placeholder />
@@ -45,7 +46,7 @@ const Branding: FC<IBrandingProps> = (props) => {
 
 	return (
 		<Link
-			href={URL}
+			href={watermarkUrl || URL}
 			target="_blank"
 			aria-label="Powered by Cognigy. Opens in new tab"
 			id={id ?? "cognigyBrandingLink"}

--- a/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
@@ -119,6 +119,7 @@ const InputPluginRenderer = ({ messages, config, onSendMessage, plugins, inputMo
 			<Branding
 				watermark={config.settings.layout.watermark}
 				watermarkText={config.settings.layout.watermarkText}
+                watermarkUrl={config.settings.layout.watermarkUrl}
 			/>
         </InputRoot>
     )

--- a/src/webchat-ui/components/plugins/input/file/DropZone.tsx
+++ b/src/webchat-ui/components/plugins/input/file/DropZone.tsx
@@ -86,6 +86,7 @@ const DropZone: FC<IDropZoneProps> = props => {
 					id="cognigyDropZoneLogo"
 					watermark={layoutSettings?.watermark}
 					watermarkText={layoutSettings?.watermarkText}
+					watermarkUrl={layoutSettings?.watermarkUrl}
 				/>
 			</DropZoneRoot>
 			<DropZoneContainer

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -284,6 +284,7 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 					id="cognigyHomeScreenBranding"
 					watermark={config?.settings?.layout?.watermark}
 					watermarkText={config?.settings?.layout?.watermarkText}
+					watermarkUrl={config?.settings?.layout?.watermarkUrl}
 				/>
 			</HomeScreenActions>
 		</HomeScreenRoot>

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -129,6 +129,7 @@ export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 					id="cognigyConversationListBranding"
 					watermark={config?.settings?.layout?.watermark}
 					watermarkText={config?.settings?.layout?.watermarkText}
+					watermarkUrl={config?.settings?.layout?.watermarkUrl}
 				/>
 			</ConversationsListActions>
 		</ConversationsListRoot>

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -33,6 +33,7 @@ export const getInitialState = (): ConfigState => ({
 			disableUrlButtonSanitization: false,
 			watermark: "default",
 			watermarkText: "Powered by Cognigy.AI",
+			watermarkUrl: "",
 		},
 		colors: {
 			primaryColor: "",


### PR DESCRIPTION
# Success criteria
Please describe what should be possible after this change. List all individual items on a separate line.

This PR adds the possibility to use custom watermark url for the watermark text 

# How to test
Please describe the individual steps on how a peer can test your change.

1. Add a watermarkUrl under settings > layout when initializing the webchat in index.html
2. Open the webchat and check the watermark link by clicking the watermark text
3. If no watermark link is provided, the watermark text should link you to the cognigy home page as before

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations
- [ ] This PR might have performance implications

# Documentation Considerations
These are hints for the documentation team to help write the docs.
