### PR TITLE
Make QRs in chat options post to the active session

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -742,7 +742,6 @@ export class WebchatUI extends React.PureComponent<
 				options,
 			});
 		} else {
-			this.props.onSwitchSession();
 			this.props.onSendMessage(text, data, options);
 		}
 	};

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -742,6 +742,26 @@ export class WebchatUI extends React.PureComponent<
 				options,
 			});
 		} else {
+			this.props.onSwitchSession();
+			this.props.onSendMessage(text, data, options);
+		}
+	};
+
+	handleSendActionButtonMessageExistingSession = (
+		text?: string,
+		data?: any,
+		options?: Partial<ISendMessageOptions>,
+	) => {
+		this.props.onSetShowHomeScreen(false);
+		this.props.onSetShowChatOptionsScreen(false);
+
+		if (this.props.config.settings.privacyNotice.enabled && !this.props.hasAcceptedTerms) {
+			this.props.onSetStoredMessage({
+				text,
+				data,
+				options,
+			});
+		} else {
 			this.props.onSendMessage(text, data, options);
 		}
 	};
@@ -1204,7 +1224,7 @@ export class WebchatUI extends React.PureComponent<
 						hasGivenRating={this.props.hasGivenRating}
 						onSendRating={this.handleSendRating}
 						onEmitAnalytics={onEmitAnalytics}
-						onSendActionButtonMessage={this.handleSendActionButtonMessage}
+						onSendActionButtonMessage={this.handleSendActionButtonMessageExistingSession}
 					/>
 				);
 


### PR DESCRIPTION
This PR fixes an issue where Quick Replies from the Chat Options Screen would post to a new session insead of the active one.

To test, configure QRs in Chat Options Endpoint settings.