### PR TITLE
Feature/88773 new webchat settings

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -108,8 +108,8 @@ See it in action:
 | watermark | string | `"default"` | Allowed values: `"default" \| "custom" \| "none"` |
 | watermarkText | string | `"Powered by Cognigy.AI"` | This will be used if watermark is set to custom |
 | watermarkUrl | string | `""` | URL to which the watermark links if a custom watermark is set. | 
-| disableBotOutputBorder | boolean | `false` | Enabling this will hide the chat bubble around AI Agent Messages |
-| botOutputMaxWidthPercentage | number | `73` | Use to set a number that will be used as a percentage value for the max-width of AI Agent Messages |
+| disableBotOutputBorder | boolean | `false` | Enabling this will hide the chat bubble around AI Agent text Messages |
+| botOutputMaxWidthPercentage | number | `73` | Use to set a number that will be used as a percentage value for the max-width of AI Agent text Messages |
 | chatWindowWidth | number | `460` | Configure the width of the Webchat in px |
 
 #### Colors

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -108,7 +108,7 @@ See it in action:
 | watermark | string | `"default"` | Allowed values: `"default" \| "custom" \| "none"` |
 | watermarkText | string | `"Powered by Cognigy.AI"` | This will be used if watermark is set to custom |
 | disableBotOutputBorder | boolean | `false` | Enabling this will hide the chat bubble around AI Agent Messages |
-| botOutputMaxWidth | number | `73` | Use to set a number that will be used as a percentage value for the max-width of AI Agent Messages |
+| botOutputMaxWidthPercentage | number | `73` | Use to set a number that will be used as a percentage value for the max-width of AI Agent Messages |
 | chatWindowWidth | number | `460` | Configure the width of the Webchat in px |
 
 #### Colors

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -107,6 +107,9 @@ See it in action:
 | disableUrlButtonSanitization | boolean | `false` | By default, 'JavaScript URLs' starting with javascript: will get removed. |
 | watermark | string | `"default"` | Allowed values: `"default" \| "custom" \| "none"` |
 | watermarkText | string | `"Powered by Cognigy.AI"` | This will be used if watermark is set to custom |
+| disableBotOutputBorder | boolean | `false` | Enabling this will hide the chat bubble around AI Agent Messages |
+| botOutputMaxWidth | number | `73` | Use to set a number that will be used as a percentage value for the max-width of AI Agent Messages |
+| chatWindowWidth | number | `460` | Configure the width of the Webchat in px |
 
 #### Colors
 | Name | Type | Default | Description |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",
-				"@cognigy/chat-components": "0.37.0",
+				"@cognigy/chat-components": "0.38.0",
 				"@cognigy/socket-client": "5.0.0-beta.21",
 				"@emotion/cache": "^10.0.29",
 				"@emotion/react": "^11.13.0",
@@ -828,9 +828,9 @@
 			}
 		},
 		"node_modules/@cognigy/chat-components": {
-			"version": "0.37.0",
-			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.37.0.tgz",
-			"integrity": "sha512-vjE1Q6DNVF48nqjjNl0D1W9dJgVUIHAu9wEI+Ycgf9qjjWZA6eqvon88oxmQ6xX+q48dIgZ+RNsfJK2xK5NBiQ==",
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.38.0.tgz",
+			"integrity": "sha512-aawL2LGrtUtgIECeekIgaAy+go6fX1M9GRxrBmmm3s8PMCDZNAiAng5jukh6in3FH7F+OG5KQfB7nAskik9yFg==",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"@braintree/sanitize-url": "^6.0.0",
-		"@cognigy/chat-components": "0.37.0",
+		"@cognigy/chat-components": "0.38.0",
 		"@cognigy/socket-client": "5.0.0-beta.21",
 		"@emotion/cache": "^10.0.29",
 		"@emotion/react": "^11.13.0",

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -139,6 +139,9 @@ export interface IWebchatSettings {
 		disableUrlButtonSanitization: boolean;
 		watermark: "default" | "custom" | "none";
 		watermarkText: string;
+		disableBotOutputBorder: boolean;
+		botOutputMaxWidth: number;
+		chatWindowWidth: number;
 	};
 	colors: {
 		primaryColor: string;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -140,7 +140,7 @@ export interface IWebchatSettings {
 		watermark: "default" | "custom" | "none";
 		watermarkText: string;
 		disableBotOutputBorder: boolean;
-		botOutputMaxWidth: number;
+		botOutputMaxWidthPercentage: number;
 		chatWindowWidth: number;
 	};
 	colors: {

--- a/src/webchat-embed/embedded-webchat-styles.css
+++ b/src/webchat-embed/embedded-webchat-styles.css
@@ -58,7 +58,6 @@
 		bottom: 90px;
 		right: 20px;
 
-		width: 460px;
 		height: 780px;
 
         border-radius: 16px;

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -960,6 +960,7 @@ export class WebchatUI extends React.PureComponent<
 											className="webchat"
 											id="webchatWindow"
 											ref={this.webchatWindowRef}
+										chatWindowWidth={this.props.config.settings.layout.chatWindowWidth}
 										>
 											{!fullscreenMessage
 												? this.renderRegularLayout(isInforming)

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -960,7 +960,7 @@ export class WebchatUI extends React.PureComponent<
 											className="webchat"
 											id="webchatWindow"
 											ref={this.webchatWindowRef}
-										chatWindowWidth={this.props.config.settings.layout.chatWindowWidth}
+											chatWindowWidth={this.props.config.settings.layout.chatWindowWidth}
 										>
 											{!fullscreenMessage
 												? this.renderRegularLayout(isInforming)

--- a/src/webchat-ui/components/presentational/WebchatRoot.tsx
+++ b/src/webchat-ui/components/presentational/WebchatRoot.tsx
@@ -1,21 +1,33 @@
 import styled from '@emotion/styled'
 import ResetCSS from "./ResetCSS";
 
-export default styled(ResetCSS)(({ theme }) => ({
-    display: 'flex',
-    flexDirection: 'column',
+interface Props {
+	chatWindowWidth?: number;
+}
 
-    backgroundColor: theme.backgroundWebchat,
+export default styled(ResetCSS)<Props>(({ theme, chatWindowWidth }) => {
+	// Fallback if chatWindowWidth is not provided
+	const finalWidth = chatWindowWidth ?? 460;
 
-    overflow: 'hidden',
+	return {
+		display: 'flex',
+		flexDirection: 'column',
+		backgroundColor: theme.backgroundWebchat,
+		overflow: 'hidden',
+		fontSize: 16,
+		fontFamily: theme.fontFamily,
 
-    fontSize: 16,
+		'@media screen and (min-width: 576px)': {
+			width: finalWidth,
+		},
 
-    fontFamily: theme.fontFamily,
-
-    '&>.content': {
-        flexGrow: 1,
-        minHeight: 0,
-        overflowY: 'auto'
-    }
-}));
+		/**
+		 * If the user’s screen is between 576px and "finalWidth" (for example: a 650px screen 
+		 *  with a 700px chatWindowWidth), we want to shrink. We add 40px to the finalWidth due to the padding.
+		 */
+		[`@media screen and (min-width: 576px) and (max-width: ${finalWidth + 40}px)`]: {
+			width: '90%',
+			right: '5%',
+		},
+	};
+});

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -33,6 +33,9 @@ export const getInitialState = (): ConfigState => ({
 			disableUrlButtonSanitization: false,
 			watermark: "default",
 			watermarkText: "Powered by Cognigy.AI",
+			disableBotOutputBorder: false,
+			botOutputMaxWidthPercentage: 73,
+			chatWindowWidth: 460,
 		},
 		colors: {
 			primaryColor: "",


### PR DESCRIPTION
https://cognigy.visualstudio.com/Team%20X/_workitems/edit/88773

related chat-components PR:
https://github.com/Cognigy/chat-components/pull/105

# Success criteria
Please describe what should be possible after this change. List all individual items on a separate line.

added 3 new webchat3 setting options:

1. disableBotOutputBorder - bot outputs without border
2. botOutputMaxWidthPercentage - bot outputs size (relative to window) in percentage
3. chatWindowWidth - width of webchat window

number 3. is handled in the Webchat repo, the others are settings for the chat components.
The challenge here was not just setting the width of the chat, but handling the media queries with a customizable value

# How to test
Please describe the individual steps on how a peer can test your change.

1. Once we merged the chat components PR, this PR will be published with the new version of chat components
2. For testing locally, build your webchat locally and add these settings to the index html:
```
settings: {
    layout: {
        disableBotOutputBorder: true,
	botOutputMaxWidthPercentage: 100,
	chatWindowWidth: 650,
    }
}
```

you can of course try it out with different 

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations
- [ ] This PR might have performance implications

# Documentation Considerations
These are hints for the documentation team to help write the docs.
