### PR TITLE
fix textcolor if bot message bubbles disabled

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -331,7 +331,7 @@ export class WebchatUI extends React.PureComponent<
 			);
 			isThemeChanged = true;
 		}
-		if (!!botMessageColor && botMessageColor !== state.theme.backgroundBotMessage) {
+		if (!!botMessageColor && botMessageColor !== state.theme.backgroundBotMessage && !props?.config?.settings?.layout?.disableBotOutputBorder) {
 			document.documentElement.style.setProperty(
 				"--webchat-background-bot-message",
 				botMessageColor,


### PR DESCRIPTION
# Success criteria
Please describe what should be possible after this change. List all individual items on a separate line.

- fixes the issue described here https://cognigy.visualstudio.com/Cognigy.AI/_git/cognigy/pullRequest/37820#1736874783
- Chat bubbles text color calculation is now also dependent on the setting for disabled borders. It will stay in default if the borders are disabled.

# How to test
Please describe the individual steps on how a peer can test your change.

1. deploy branch with disableBotOutputBorder enabled  ( `settings.layout.disableBotOutputBorder` ) and botMessageColor set to a dark color (use endpoint settings UI or configure `settings.colors.botMessageColor`)
2. bot outputs should now be black text on white bg, instead of white text on white bg
3. you can also check with this PR branch https://cognigy.visualstudio.com/Cognigy.AI/_git/cognigy/pullrequest/37820

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations
- [ ] This PR might have performance implications

# Documentation Considerations
These are hints for the documentation team to help write the docs.
