### PR TITLE
feat: #89718 persistent menu

### DIFF
--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -77,6 +77,8 @@ There are several classes that you need to take in consideration if you want to 
 * *webchat-rating-widget-send-button*
 * *webchat-chat-options-footer-link*
 * *webchat-chat-options-footer-link-text*
+* *webchat-input-persistent-menu-button*
+* *webchat-input-persistent-menu-item*
 
 If you want to be sure that the custom CSS that you apply will be shown, you will have to add some other selectors to those classes, for the Webchat we will use the attribute selectors:
 ```CSS

--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -78,7 +78,9 @@ There are several classes that you need to take in consideration if you want to 
 * *webchat-chat-options-footer-link*
 * *webchat-chat-options-footer-link-text*
 * *webchat-input-persistent-menu-button*
+* *webchat-input-persistent-menu*
 * *webchat-input-persistent-menu-item*
+* *webchat-input-persistent-menu-item-container*
 
 If you want to be sure that the custom CSS that you apply will be shown, you will have to add some other selectors to those classes, for the Webchat we will use the attribute selectors:
 ```CSS
@@ -1072,5 +1074,48 @@ The look and feel of the selected date can be changed.
   color: hsla(0, 0%, 100%, 0.95);
   font-weight: bold;
   font-size: 22px;
+}
+```
+
+### Persistent Menu
+
+* *webchat-input-persistent-menu-button*  
+This class is used to style the persistent menu icon. You can customize the size, color, and background.
+```CSS
+[data-cognigy-webchat-root] .webchat-input-persistent-menu-button {
+    background-color: #ffffff;
+    color: #000000;
+    font-size: 16px;
+}
+```
+
+* *webchat-input-persistent-menu*  
+This class is used to style the persistent menu container, which includes the title and menu items. You can adjust the layout, background color, and padding.
+```CSS
+[data-cognigy-webchat-root] .webchat-input-persistent-menu {
+    background-color: #f9f9f9;
+    padding: 15px;
+    border-radius: 5px;
+}
+```
+
+* *webchat-input-persistent-menu-item*  
+This class is used to style individual items in the persistent menu. You can customize the background color, font, and padding.
+```CSS
+[data-cognigy-webchat-root] .webchat-input-persistent-menu-item {
+    background-color: #f0f0f0;
+    padding: 10px;
+    font-family: Arial, Helvetica, sans-serif;
+}
+```
+
+* *webchat-input-persistent-menu-item-container*  
+This class is used to style the container that holds the persistent menu items. You can adjust the layout, spacing, and border.
+```CSS
+[data-cognigy-webchat-root] .webchat-input-persistent-menu-item-container {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #ccc;
+    margin: 5px;
 }
 ```

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -99,6 +99,8 @@ See it in action:
 | agentLogoUrl | string | `""` | Human Agent avatar which will be displayed above each Human Agent message. Recommended img size: 28px x 28px. Please note that specified avatar will be used for the Human Agent, only if 'useOtherAgentLogo' is set to 'true'. |
 | inputAutogrowMaxRows | number | `4` | Maximum Number of Input Rows  |
 | enableInputCollation | boolean | `false` | If enabled, messages will be combined into a single message, dependent on the time set with `inputCollationTimeout` |
+| enablePersistentMenu | boolean | `false` | If enabled, persistent menu will be displayed left to the chat message input box |
+| persistentMenu | object | see [Persistent Menu](#persistent-menu) | The Persistent Menu ensures quick access to different conversation stages, guides users, offers features, shares information, and enhances the overall user experience. |
 | inputCollationTimeout | number | `1000` | timeout value for input collation |
 | dynamicImageAspectRatio | boolean | `false` | Use to disable forced aspect ratio for images in chat elements |
 | disableInputAutocomplete | boolean | `false` | Use to disable browser autocomplete for the input field |
@@ -111,6 +113,18 @@ See it in action:
 | disableBotOutputBorder | boolean | `false` | Enabling this will hide the chat bubble around AI Agent text Messages |
 | botOutputMaxWidthPercentage | number | `73` | Use to set a number that will be used as a percentage value for the max-width of AI Agent text Messages |
 | chatWindowWidth | number | `460` | Configure the width of the Webchat in px |
+
+#### Persistent Menu
+| Name | Type | Default | Descrption |
+| - | - | - | - |
+| title | string | `""` | The title for your Persistent Menu. This title will be displayed to the users. |  
+|menuItems|array of [Peristent Menu Items](#persistent-menu-items) | `[]`| Items to be displayed inside the menu |
+
+#### Persistent Menu Items
+| Name | Type | Default | Descrption |
+| - | - | - | - |
+| title | string | `""` | The text that you want users to see in the Persistent Menu. This text should be descriptive and clear, indicating the function or action associated with the menu item. |
+| payload | string | `""` | The payload text that will be sent to your AI Agent flow when the user selects this menu item. This payload can be a simple word or phrase, or it can be a more complex query depending on your AI Agent's functionality. |
 
 #### Colors
 | Name | Type | Default | Description |
@@ -359,6 +373,7 @@ Additional Settings to configure the webchat widget behavior <br>
 | bot | string | `"bot" \| "user"` |
 | user | string | `"bot" \| "user"` |
 
+
 #### Settings Interface
 The full interface for the Webchat Settings.
 _Note: All settings can be optionally loaded, a full object is not required._
@@ -379,6 +394,14 @@ interface IWebchatSettings {
 		dynamicImageAspectRatio: boolean;
 		disableInputAutocomplete: boolean;
 		enableGenericHTMLStyling: boolean;
+		enablePeristentMenu:boolean;
+		persistentMenu: {
+			title:string;
+			menuItems: {
+				title:string;
+				payload:string
+			}[]
+		};
 		disableHtmlContentSanitization: boolean;
 		disableUrlButtonSanitization: boolean;
 		watermark: "default" | "custom" | "none";

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -119,6 +119,16 @@ export interface IWebchatV2Settings {
 	privacyUrl: string;
 }
 
+export interface IPersistentMenuItem {
+    title: string;
+    payload: string;
+}
+
+export interface IPersistentMenu {
+    title: string;
+    menuItems: IPersistentMenuItem[];
+}
+
 export interface IWebchatSettings {
 	// Settings that are also configurable via the Endpoint Editor in Cognigy.AI
 	layout: {
@@ -131,6 +141,8 @@ export interface IWebchatSettings {
 		agentLogoUrl: string;
 		inputAutogrowMaxRows: number;
 		enableInputCollation: boolean;
+		enablePersistentMenu:boolean;
+		persistentMenu: IPersistentMenu;
 		inputCollationTimeout: number;
 		dynamicImageAspectRatio: boolean;
 		disableInputAutocomplete: boolean;

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -12,6 +12,7 @@ import { IUploadFileMetaData } from "../../../../../common/interfaces/file-uploa
 import { IFile } from "../../../../../webchat/store/input/input-reducer";
 import MediaQuery from "react-responsive";
 import PersistentMenu from "../menu/PersistentMenu";
+import IconButton from "../../../presentational/IconButton";
 
 const InputWrapper = styled.div(() => ({
 	display: "flex",
@@ -75,21 +76,7 @@ const Button = styled.button(({ theme }) => ({
 }));
 
 const MenuButton = styled(Button)(({ theme }) => ({
-	alignSelf: "flex-end",
-    padding: `4px ${theme.unitSize/2}px`,
-	borderRadius: "50%",
-	margin:0,
-	"&:hover": {
-		fill: theme.primaryColor,
-	},
-	"&:focus": {
-		fill: theme.greyContrastColor,
-		backgroundColor: theme.greyWeakColor,
-		outline: "none  ",
-	},
-	"&:active": {
-		fill: theme.primaryStrongColor,
-	},
+	
 }));
 
 const iconButtonStyles = {
@@ -470,7 +457,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 									onClick={() => this.setState({ isMenuOpen: !isMenuOpen })}
 									aria-label="Toggle persistent menu"
 									aria-expanded={isMenuOpen}
-									className="webchat-input-button-menu"
+									className="webchat-input-persistent-menu-button"
 									id="webchatInputButtonMenu"
 								>
 									<MenuIcon />
@@ -521,12 +508,16 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 											onFocus={this.handleFocus}
 											onBlur={this.handleBlur}
 											onKeyDown={this.handleInputKeyDown}
-									placeholder={props.config.settings.behavior.inputPlaceholder}
+											placeholder={
+												props.config.settings.behavior.inputPlaceholder
+											}
 											className="webchat-input-message-input"
 											aria-label="Message to send"
 											minRows={1}
 											maxRows={inputAutogrowMaxRows}
-									autoComplete={disableInputAutocomplete ? "off" : undefined}
+											autoComplete={
+												disableInputAutocomplete ? "off" : undefined
+											}
 											spellCheck={false}
 											id="webchatInputMessageInputInTextMode"
 											style={matches ? { fontSize: "16px" } : undefined}
@@ -567,7 +558,8 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 
 								<SubmitButton
 									disabled={
-								(this.state.text === "" && isFileListEmpty) || fileUploadError
+										(this.state.text === "" && isFileListEmpty) ||
+										fileUploadError
 									}
 									className="webchat-input-button-send cc-rtl-flip"
 									aria-label="Send Message"

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -75,9 +75,6 @@ const Button = styled.button(({ theme }) => ({
 	},
 }));
 
-const MenuButton = styled(Button)(({ theme }) => ({
-	
-}));
 
 const iconButtonStyles = {
 	padding: "8px",
@@ -88,6 +85,7 @@ const iconButtonStyles = {
 	minHeight: "32px",
 };
 
+const MenuButton = styled(Button)(({ theme }) => (iconButtonStyles));
 const AttachFileButton = styled(Button)(({ theme }) => (iconButtonStyles));
 
 const SpeechButton = styled(Button)(({ theme }) => ({

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -450,7 +450,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 			enablePersistentMenu,
 			persistentMenu,
 		} = layout;
-
+		const showPersistentMenu = enablePersistentMenu && persistentMenu?.menuItems.length > 0;
 		const { disableInputAutofocus } = widgetSettings;
 
 		const isFileAttachmentEnabled = fileStorageSettings?.enabled;
@@ -464,7 +464,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 						onSubmit={this.handleSubmit}
 						className={classnames("webchat-input-menu-form")}
 					>
-						{enablePersistentMenu && (
+						{showPersistentMenu && (
 							<>
 								<MenuButton
 									onClick={() => this.setState({ isMenuOpen: !isMenuOpen })}
@@ -477,7 +477,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 								</MenuButton>
 							</>
 						)}
-						{isMenuOpen ? (
+						{isMenuOpen && showPersistentMenu ? (
 							<PersistentMenu
 								title={persistentMenu.title}
 								menuItems={persistentMenu.menuItems}

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -20,9 +20,9 @@ const InputWrapper = styled.div(() => ({
 	gap: 12,
 }));
 
-const InputForm = styled.form(() => ({
+const InputForm = styled.form<{persistentMenuOpen:boolean}>(({persistentMenuOpen}) => ({
 	display: "flex",
-	alignItems: "center",
+	alignItems: persistentMenuOpen ? "flex-end" : "center",
 	gap: 12,
 	marginBottom: 0,
 }));
@@ -85,7 +85,12 @@ const iconButtonStyles = {
 	minHeight: "32px",
 };
 
-const MenuButton = styled(Button)(({ theme }) => (iconButtonStyles));
+const MenuButton = styled(Button)<{open:boolean}>(({ theme,open }) => ({
+	...iconButtonStyles,
+	padding:"6px",
+	fill: open ? theme.primaryColor : "initial",
+}));
+
 const AttachFileButton = styled(Button)(({ theme }) => (iconButtonStyles));
 
 const SpeechButton = styled(Button)(({ theme }) => ({
@@ -448,6 +453,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 					<InputForm
 						onSubmit={this.handleSubmit}
 						className={classnames("webchat-input-menu-form")}
+						persistentMenuOpen={isMenuOpen}
 					>
 						{showPersistentMenu && (
 							<>
@@ -457,6 +463,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 									aria-expanded={isMenuOpen}
 									className="webchat-input-persistent-menu-button"
 									id="webchatInputButtonMenu"
+									open={isMenuOpen}
 								>
 									<MenuIcon />
 								</MenuButton>

--- a/src/webchat-ui/components/plugins/input/base/baseline-menu-24px.svg
+++ b/src/webchat-ui/components/plugins/input/base/baseline-menu-24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>

--- a/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
+++ b/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
@@ -50,8 +50,7 @@ const PersistentMenuItem = styled.button(({ theme }) => ({
 	},
 
 	"&:focus": {
-		outline: "none",
-		boxShadow: `0 0 3px 1px ${theme.primaryWeakColor}`,
+		outline: `2px solid ${theme.primaryColor}`,
 	},
 }));
 

--- a/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
+++ b/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
@@ -21,26 +21,21 @@ const PersistentMenuContainer = styled.div(({ theme }) => ({
 
 const PersistentMenuTitle = styled.h5(({ theme }) => ({
 	color: "hsla(0, 0%, 0%, .3)",
-	padding: `${theme.unitSize * 2}px`,
+	padding: `0 ${theme.unitSize * 2}px ${theme.unitSize}px`,
 	margin: 0,
 }));
 
 const PersistentMenuItem = styled.button(({ theme }) => ({
 	display: "block",
 	position: "relative",
-	// width: '100%',
-	// border: 'none',
 	backgroundColor: "transparent",
 	outline: "none",
-	// margin: 0,
 	cursor: "pointer",
 	textAlign: "left",
 	color: "hsla(0, 0%, 0%, .87)",
 
 	padding: `${theme.unitSize}px ${theme.unitSize * 3}px`,
 	margin: theme.unitSize,
-	// borderTopLeftRadius: theme.unitSize * 2,
-	// borderBottomLeftRadius: theme.unitSize * 2,
 	borderRadius: theme.unitSize * 2,
 	borderStyle: "solid",
 	borderColor: "hsla(0, 0%, 0%, .12)",

--- a/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
+++ b/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { IPersistentMenuItem } from "../../../../../common/interfaces/webchat-config";
+import styled from "@emotion/styled";
+
+interface PersistentMenuProps {
+	title: string;
+	menuItems: IPersistentMenuItem[];
+	onSelect: (item: IPersistentMenuItem) => void;
+}
+
+const PersistentMenuContainer = styled.div(({ theme }) => ({
+	minHeight: 0,
+	flexGrow: 1,
+	maxHeight: theme.blockSize * 3,
+	overflowY: "auto",
+	paddingBottom: theme.unitSize,
+	"&:focus": {
+		outline: "none",
+	},
+}));
+
+const PersistentMenuTitle = styled.h5(({ theme }) => ({
+	color: "hsla(0, 0%, 0%, .3)",
+	padding: `${theme.unitSize * 2}px`,
+	margin: 0,
+}));
+
+const PersistentMenuItem = styled.button(({ theme }) => ({
+	display: "block",
+	position: "relative",
+	// width: '100%',
+	// border: 'none',
+	backgroundColor: "transparent",
+	outline: "none",
+	// margin: 0,
+	cursor: "pointer",
+	textAlign: "left",
+	color: "hsla(0, 0%, 0%, .87)",
+
+	padding: `${theme.unitSize}px ${theme.unitSize * 3}px`,
+	margin: theme.unitSize,
+	// borderTopLeftRadius: theme.unitSize * 2,
+	// borderBottomLeftRadius: theme.unitSize * 2,
+	borderRadius: theme.unitSize * 2,
+	borderStyle: "solid",
+	borderColor: "hsla(0, 0%, 0%, .12)",
+	borderWidth: 1,
+
+	"&:hover": {
+		backgroundColor: "hsla(0, 0%, 0%, .08)",
+	},
+
+	"&:active": {
+		backgroundColor: "hsla(0, 0%, 0%, .12)",
+	},
+
+	"&:focus": {
+		outline: "none",
+		boxShadow: `0 0 3px 1px ${theme.primaryWeakColor}`,
+	},
+}));
+
+const PersistentMenu: React.FC<PersistentMenuProps> = ({ title, menuItems, onSelect }) => {
+	const handleMenuItem = (item: IPersistentMenuItem) => {
+		onSelect(item);
+	};
+
+	const menuRef = React.useRef<HTMLDivElement>(null);
+	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		const { key, target } = e;
+		let newFocusTarget: HTMLButtonElement | null = null;
+
+		if (!menuRef.current) return;
+
+		switch (key) {
+			case "ArrowUp":
+				newFocusTarget =
+					// @ts-expect-error Missing type for previousElementSibling in React Types
+					((target.previousElementSibling as HTMLButtonElement) ||
+						menuRef.current.lastChild) as HTMLButtonElement;
+				break;
+			case "ArrowDown":
+				newFocusTarget = (target.nextElementSibling ||
+					menuRef.current.firstChild) as HTMLButtonElement;
+				break;
+			case "Home":
+				newFocusTarget = menuRef.current.firstChild as HTMLButtonElement;
+				break;
+			case "End":
+				newFocusTarget = menuRef.current.lastChild as HTMLButtonElement;
+				break;
+			default:
+				break;
+		}
+
+		if (newFocusTarget !== null) {
+			newFocusTarget.focus();
+			e.preventDefault();
+		}
+	};
+	return (
+		<PersistentMenuContainer className="webchat-input-persistent-menu" tabIndex={-1}>
+			<PersistentMenuTitle>{title}</PersistentMenuTitle>
+			<div
+				aria-labelledby="persistentMenuTitle"
+				role="menu"
+				ref={menuRef}
+				onKeyDown={handleMenuKeyDown}
+			>
+				{menuItems.map((item, index) => (
+					<PersistentMenuItem
+						key={`${item.title}${item.payload}`}
+						onClick={() => handleMenuItem(item)}
+						className="webchat-input-persistent-menu-item"
+						role="menuitem"
+						autoFocus={index === 0}
+						tabIndex={index === 0 ? 0 : -1}
+					>
+						{item.title}
+					</PersistentMenuItem>
+				))}
+			</div>
+		</PersistentMenuContainer>
+	);
+};
+
+export default PersistentMenu;

--- a/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
+++ b/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { IPersistentMenuItem } from "../../../../../common/interfaces/webchat-config";
 import styled from "@emotion/styled";
+import { ActionButtons } from "@cognigy/chat-components";
+import { IWebchatButton } from "@cognigy/socket-client";
 
 interface PersistentMenuProps {
 	title: string;
@@ -17,49 +19,27 @@ const PersistentMenuContainer = styled.div(({ theme }) => ({
 	"&:focus": {
 		outline: "none",
 	},
+	marginRight: "-20px" /* to compensate for src/webchat-ui/components/plugins/InputPluginRenderer.tsx:42 */
 }));
+
+const ActionButtonsWrapper = styled.div(({ theme }) => ({
+	"> div": {
+		flexDirection: "column",
+	},
+	paddingLeft: theme.unitSize,
+}));
+
 
 const PersistentMenuTitle = styled.h5(({ theme }) => ({
 	color: "hsla(0, 0%, 0%, .3)",
-	padding: `0 ${theme.unitSize * 2}px ${theme.unitSize}px`,
+	padding: `0 ${theme.unitSize}px ${theme.unitSize}px`,
 	margin: 0,
 }));
 
-const PersistentMenuItem = styled.button(({ theme }) => ({
-	display: "block",
-	position: "relative",
-	backgroundColor: "transparent",
-	outline: "none",
-	cursor: "pointer",
-	textAlign: "left",
-	color: "hsla(0, 0%, 0%, .87)",
-
-	padding: `${theme.unitSize}px ${theme.unitSize * 3}px`,
-	margin: theme.unitSize,
-	borderRadius: theme.unitSize * 2,
-	borderStyle: "solid",
-	borderColor: "hsla(0, 0%, 0%, .12)",
-	borderWidth: 1,
-
-	"&:hover": {
-		backgroundColor: "hsla(0, 0%, 0%, .08)",
-	},
-
-	"&:active": {
-		backgroundColor: "hsla(0, 0%, 0%, .12)",
-	},
-
-	"&:focus": {
-		outline: `2px solid ${theme.primaryColor}`,
-	},
-}));
-
 const PersistentMenu: React.FC<PersistentMenuProps> = ({ title, menuItems, onSelect }) => {
-	const handleMenuItem = (item: IPersistentMenuItem) => {
-		onSelect(item);
-	};
 
 	const menuRef = React.useRef<HTMLDivElement>(null);
+
 	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
 		const { key, target } = e;
 		let newFocusTarget: HTMLButtonElement | null = null;
@@ -92,28 +72,36 @@ const PersistentMenu: React.FC<PersistentMenuProps> = ({ title, menuItems, onSel
 			e.preventDefault();
 		}
 	};
+
+	const buttons: IWebchatButton[] = menuItems.map(item => ({
+		title: item.title,
+		type: "postback",
+		payload: item.payload,
+	}));
+
 	return (
 		<PersistentMenuContainer className="webchat-input-persistent-menu" tabIndex={-1}>
 			<PersistentMenuTitle>{title}</PersistentMenuTitle>
-			<div
+			<ActionButtonsWrapper
 				aria-labelledby="persistentMenuTitle"
 				role="menu"
 				ref={menuRef}
 				onKeyDown={handleMenuKeyDown}
 			>
-				{menuItems.map((item, index) => (
-					<PersistentMenuItem
-						key={`${item.title}${item.payload}`}
-						onClick={() => handleMenuItem(item)}
-						className="webchat-input-persistent-menu-item"
-						role="menuitem"
-						autoFocus={index === 0}
-						tabIndex={index === 0 ? 0 : -1}
-					>
-						{item.title}
-					</PersistentMenuItem>
-				))}
-			</div>
+				<ActionButtons
+					buttonClassName="webchat-input-persistent-menu-item"
+					containerClassName="webchat-input-persistent-menu-item-container"
+					payload={buttons}
+					config={{}}
+					onEmitAnalytics={() => {}}
+					action={(text) => {
+						const item = menuItems.find(i => i.payload === text);
+						if (item) {
+							onSelect(item);
+						}
+					}}
+				/>
+			</ActionButtonsWrapper>
 		</PersistentMenuContainer>
 	);
 };


### PR DESCRIPTION
# Success criteria
Please describe what should be possible after this change. List all individual items on a separate line.

- Users can configure persistent menu in Webchat 3 endpoint settings editor.
- When enabled, the persistent menu should be visible in the chat widget left to the input box 
- Users can toggle this menu and choose items from the menu
- Upon selecting a menu item , the selected item is sent as a user message
- The menu is  accessible via keyboard navigation

# How to test
Please describe the individual steps on how a peer can test your change.

1. Enable Persistent menu in endpoint editor with at least one menu 
2. Observer the webchat interface shows a a hamburger menu icon left to the text input
3. Click the menu button 
4. Observe a menu is opened 
5. Click on any of the menu item
6. Observe the selected item is sent as a message'
7. The menu is also hidden and text input is displayed back to the user

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations
- [ ] This PR might have performance implications
https://cognigy.visualstudio.com/Boron/_workitems/edit/89718

# Documentation Considerations
These are hints for the documentation team to help write the docs.
