### PR TITLE
Feature/90411 increase size of clickable areas

### DIFF
--- a/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
@@ -39,7 +39,7 @@ const InputRoot = styled.div(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: 12,
-    padding: "24px 20px 12px 20px",
+	padding: "12px 20px",
     borderBottom: '2px solid transparent',
     borderBottomLeftRadius: theme.unitSize * 2,
     borderBottomRightRadius: theme.unitSize * 2,

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -72,23 +72,20 @@ const Button = styled.button(({ theme }) => ({
 	},
 }));
 
-const AttachFileButton = styled(Button)(({ theme }) => ({
+const iconButtonStyles = {
 	padding: "8px",
 	display: "flex",
 	alignItems: "center",
 	justifyContent: "center",
 	minWidth: "32px",
 	minHeight: "32px",
-}));
+};
+
+const AttachFileButton = styled(Button)(({ theme }) => (iconButtonStyles));
 
 const SpeechButton = styled(Button)(({ theme }) => ({
+	...iconButtonStyles,
 	position: "relative",
-	padding: "8px",
-	display: "flex",
-	alignItems: "center",
-	justifyContent: "center",
-	minWidth: "32px",
-	minHeight: "32px",
 
 	"&.webchat-input-button-speech-active": {
 		fill: theme.textLight,
@@ -130,14 +127,7 @@ const HiddenFileInput = styled.input(() => ({
 	display: "none",
 }));
 
-const SubmitButton = styled(Button)(({ theme }) => ({
-	padding: "8px",
-	display: "flex",
-	alignItems: "center",
-	justifyContent: "center",
-	minWidth: "32px",
-	minHeight: "32px",
-}));
+const SubmitButton = styled(Button)(({ theme }) => (iconButtonStyles));
 
 export interface TextInputState {
 	text: string;

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -72,10 +72,23 @@ const Button = styled.button(({ theme }) => ({
 	},
 }));
 
-const AttachFileButton = styled(Button)(({ theme }) => ({}));
+const AttachFileButton = styled(Button)(({ theme }) => ({
+	padding: "8px",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	minWidth: "32px",
+	minHeight: "32px",
+}));
 
 const SpeechButton = styled(Button)(({ theme }) => ({
 	position: "relative",
+	padding: "8px",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	minWidth: "32px",
+	minHeight: "32px",
 
 	"&.webchat-input-button-speech-active": {
 		fill: theme.textLight,

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -28,6 +28,7 @@ const TextArea = styled(TextareaAutosize)(({ theme }) => ({
 	display: "block",
 	flexGrow: 1,
 	alignSelf: "stretch",
+	padding: "8px 2px",
 
 	border: "none",
 	boxSizing: "border-box",
@@ -120,7 +121,14 @@ const HiddenFileInput = styled.input(() => ({
 	display: "none",
 }));
 
-const SubmitButton = styled(Button)(({ theme }) => ({}));
+const SubmitButton = styled(Button)(({ theme }) => ({
+	padding: "8px",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	minWidth: "32px",
+	minHeight: "32px",
+}));
 
 export interface TextInputState {
 	text: string;

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -101,8 +101,6 @@ const SpeechIcon = styled(SpeechIconSVG)(() => ({
 
 const SpeechButtonBackground = styled.div(({ theme }) => ({
 	position: "absolute",
-	top: "-6px",
-	left: "-6px",
 	backgroundColor: theme.primaryColor,
 	height: 28,
 	width: 28,
@@ -111,8 +109,6 @@ const SpeechButtonBackground = styled.div(({ theme }) => ({
 
 const SpeechButtonAnimatedBackground = styled.div(({ theme }) => ({
 	position: "absolute",
-	top: "-6px",
-	left: "-6px",
 	backgroundColor: theme.primaryColor,
 	opacity: 0.2,
 	height: 28,


### PR DESCRIPTION
https://cognigy.visualstudio.com/Team%20X/_workitems/edit/90411

# Success criteria
Please describe what should be possible after this change. List all individual items on a separate line.

- clickable areas in the input area (input field + buttons) are increased
- visual layout remains the same

Before:
![Screenshot from 2025-02-18 14-59-13](https://github.com/user-attachments/assets/2ca17752-c14f-44f7-9304-19c8095b598a)
![Screenshot from 2025-02-18 14-59-15](https://github.com/user-attachments/assets/fbcf7839-fe95-4a17-a68b-e6feac5af4b8)

After:
![Screenshot from 2025-02-18 14-57-35](https://github.com/user-attachments/assets/865e4052-68e0-4df6-ae9d-b0fd256de82a)
![Screenshot from 2025-02-18 14-57-29](https://github.com/user-attachments/assets/fecc8722-f598-4df7-bb2f-949892fd6dc2)


# How to test
Please describe the individual steps on how a peer can test your change.

1. check clickable areas
2. also check buttons layout in the input area (send button / stt button / attachment button - enable stt and attachment in endpoint settings)
3. also click (activate) stt button to see its background and check the layout

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations
- [ ] This PR might have performance implications

# Documentation Considerations
These are hints for the documentation team to help write the docs.
