### PR TITLE
feat: add customizable text for start new conversation button

### DIFF
--- a/cypress/e2e/collated-text-inputs.cy.ts
+++ b/cypress/e2e/collated-text-inputs.cy.ts
@@ -128,7 +128,7 @@ describe("collated text inputs", () => {
 					.should("not.be.disabled")
 					.focus()
 					.click();
-				cy.get(".webchat-message-row.user", { timeout: 100 }).contains("foobar003qr01");
+				cy.get(".webchat-message-row.user", { timeout: 1000 }).contains("foobar003qr01");
 			});
 
 			// Second run - verify disabled state

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -210,15 +210,15 @@ All business hours settings require the setting `embeddingConfiguration.awaitEnd
 | unreadMessageTitleTextPlural | string  | `"New Messages"` | The website title that is displayed when the user retrieved more than one new message          |
 
 #### Home Screen
-
-| Name                        | Type    | Default                                           | Description                                                 |
-| --------------------------- | ------- | ------------------------------------------------- | ----------------------------------------------------------- |
-| enabled                     | boolean | `true`                                            | Enables the Home Screen feature                             |
-| welcomeText                 | string  | `"Welcome! How can we help you?"`                 | Welcome text on the home screen                             |
-| background                  | object  | [Home Screen Background](#home-screen-background) | Configure the Home Screen background                        |
-| startConversationButtonText | string  | `"Start conversation"`                            | Configure the text shown on the "Start Conversation" button |
-| previousConversations       | object  | [Previous Conversations](#previous-conversations) | Configure the Previous Conversations feature                |
-| conversationStarters        | object  | [Conversation Starters](#conversation-starters)   | Configure Conversation Starters on the Home Screen          |
+| Name | Type | Default | Description |
+| - | - | - | - |
+| enabled | boolean | `true` | Enables the Home Screen feature  |
+| welcomeText | string | `"Welcome! How can we help you?"` | Welcome text on the home screen |
+| background | object | [Home Screen Background](#home-screen-background) | Configure the Home Screen background |
+| startConversationButtonText | string | `"Start conversation"` | Configure the text shown on the "Start Conversation" button |
+| startNewConversationButtonText | string | `"Start new conversation"` | Configure the text shown on the "Start new conversation" button |
+| previousConversations | object | [Previous Conversations](#previous-conversations) | Configure the Previous Conversations feature |
+| conversationStarters | object | [Conversation Starters](#conversation-starters) | Configure Conversation Starters on the Home Screen |
 
 ##### Home Screen Background
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -216,7 +216,6 @@ All business hours settings require the setting `embeddingConfiguration.awaitEnd
 | welcomeText | string | `"Welcome! How can we help you?"` | Welcome text on the home screen |
 | background | object | [Home Screen Background](#home-screen-background) | Configure the Home Screen background |
 | startConversationButtonText | string | `"Start conversation"` | Configure the text shown on the "Start Conversation" button |
-| startNewConversationButtonText | string | `"Start new conversation"` | Configure the text shown on the "Start new conversation" button |
 | previousConversations | object | [Previous Conversations](#previous-conversations) | Configure the Previous Conversations feature |
 | conversationStarters | object | [Conversation Starters](#conversation-starters) | Configure Conversation Starters on the Home Screen |
 
@@ -228,12 +227,12 @@ All business hours settings require the setting `embeddingConfiguration.awaitEnd
 | color    | string | `""`    | CSS color code or gradient                                                                                  |
 
 ##### Previous Conversations
-
-| Name       | Type    | Default                    | Description                                                                 |
-| ---------- | ------- | -------------------------- | --------------------------------------------------------------------------- |
-| enabled    | boolean | `true`                     | If enabled, the "Previous Conversations" button is shown on the Home Screen |
-| buttonText | string  | `"Previous conversations"` | Configure the "Previous Conversations" button                               |
-| title      | string  | `""`                       | Configure the Header of the "Previous Conversations" page                   |
+| Name | Type | Default | Description |
+| - | - | - | - |
+| enabled | boolean | `true` | If enabled, the "Previous Conversations" button is shown on the Home Screen  |
+| startNewConversationButtonText | string | `"Start new conversation"` | Configure the text shown on the "Start new conversation" button |
+| buttonText | string | `"Previous conversations"` | Configure the "Previous Conversations" button |
+| title | string | `""` | Configure the Header of the "Previous Conversations" page |
 
 ##### Conversation Starters
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -210,14 +210,15 @@ All business hours settings require the setting `embeddingConfiguration.awaitEnd
 | unreadMessageTitleTextPlural | string  | `"New Messages"` | The website title that is displayed when the user retrieved more than one new message          |
 
 #### Home Screen
-| Name | Type | Default | Description |
-| - | - | - | - |
-| enabled | boolean | `true` | Enables the Home Screen feature  |
-| welcomeText | string | `"Welcome! How can we help you?"` | Welcome text on the home screen |
-| background | object | [Home Screen Background](#home-screen-background) | Configure the Home Screen background |
-| startConversationButtonText | string | `"Start conversation"` | Configure the text shown on the "Start Conversation" button |
-| previousConversations | object | [Previous Conversations](#previous-conversations) | Configure the Previous Conversations feature |
-| conversationStarters | object | [Conversation Starters](#conversation-starters) | Configure Conversation Starters on the Home Screen |
+
+| Name                        | Type    | Default                                           | Description                                                 |
+| --------------------------- | ------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| enabled                     | boolean | `true`                                            | Enables the Home Screen feature                             |
+| welcomeText                 | string  | `"Welcome! How can we help you?"`                 | Welcome text on the home screen                             |
+| background                  | object  | [Home Screen Background](#home-screen-background) | Configure the Home Screen background                        |
+| startConversationButtonText | string  | `"Start conversation"`                            | Configure the text shown on the "Start Conversation" button |
+| previousConversations       | object  | [Previous Conversations](#previous-conversations) | Configure the Previous Conversations feature                |
+| conversationStarters        | object  | [Conversation Starters](#conversation-starters)   | Configure Conversation Starters on the Home Screen          |
 
 ##### Home Screen Background
 
@@ -227,12 +228,13 @@ All business hours settings require the setting `embeddingConfiguration.awaitEnd
 | color    | string | `""`    | CSS color code or gradient                                                                                  |
 
 ##### Previous Conversations
-| Name | Type | Default | Description |
-| - | - | - | - |
-| enabled | boolean | `true` | If enabled, the "Previous Conversations" button is shown on the Home Screen  |
-| startNewConversationButtonText | string | `"Start new conversation"` | Configure the text shown on the "Start new conversation" button |
-| buttonText | string | `"Previous conversations"` | Configure the "Previous Conversations" button |
-| title | string | `""` | Configure the Header of the "Previous Conversations" page |
+
+| Name                           | Type    | Default                    | Description                                                                 |
+| ------------------------------ | ------- | -------------------------- | --------------------------------------------------------------------------- |
+| enabled                        | boolean | `true`                     | If enabled, the "Previous Conversations" button is shown on the Home Screen |
+| startNewConversationButtonText | string  | `"Start new conversation"` | Configure the text shown on the "Start new conversation" button             |
+| buttonText                     | string  | `"Previous conversations"` | Configure the "Previous Conversations" button                               |
+| title                          | string  | `""`                       | Configure the Header of the "Previous Conversations" page                   |
 
 ##### Conversation Starters
 

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -218,8 +218,8 @@ export interface IWebchatSettings {
 			color: string;
 		};
 		startConversationButtonText: string;
-		startNewConversationButtonText: string;
 		previousConversations: {
+			startNewConversationButtonText: string;
 			enabled: boolean;
 			buttonText: string;
 			title: string;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -218,6 +218,7 @@ export interface IWebchatSettings {
 			color: string;
 		};
 		startConversationButtonText: string;
+		startNewConversationButtonText: string;
 		previousConversations: {
 			enabled: boolean;
 			buttonText: string;

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -125,7 +125,7 @@ export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 					className="webchat-prev-conversations-send-button"
 					data-testid="webchat-start-chat-button"
 				>
-					Start new conversation
+					{config.settings.homeScreen.startNewConversationButtonText ?? "Start new conversation"}
 				</StartButton>
 				<Branding
 					id="cognigyConversationListBranding"

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -125,7 +125,7 @@ export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 					className="webchat-prev-conversations-send-button"
 					data-testid="webchat-start-chat-button"
 				>
-					{config.settings.homeScreen.startNewConversationButtonText ?? "Start new conversation"}
+					{config.settings.homeScreen?.previousConversations?.startNewConversationButtonText ?? "Start new conversation"}
 				</StartButton>
 				<Branding
 					id="cognigyConversationListBranding"

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -125,7 +125,8 @@ export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 					className="webchat-prev-conversations-send-button"
 					data-testid="webchat-start-chat-button"
 				>
-					{config.settings.homeScreen?.previousConversations?.startNewConversationButtonText ?? "Start new conversation"}
+					{config.settings.homeScreen?.previousConversations
+						?.startNewConversationButtonText ?? "Start new conversation"}
 				</StartButton>
 				<Branding
 					id="cognigyConversationListBranding"


### PR DESCRIPTION
See ([Ticket](https://cognigy.visualstudio.com/Boron/_workitems/edit/79571))
# Success criteria
- Under home screen section in endpoint settings , start new conversation button text should be displayed above previous conversation button text
- The new setting should be handled in webchat3
- The button text should respect this new setting
- The button should be documented in embedding.md

# How to test

Please describe the individual steps on how a peer can test your change.

1. Create a webchat v3 endpoint
2. Open home screen section
3. Observer Start new Conversation button field is visible with default text
4. Change the default text 
5. Save. 
6. Open webchat with the configured endpoint. 
7. Go to previous conversation
8. Observe the Start new button text is same as what you entered in the endpoints editor


# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations
- [ ] This PR might have performance implications

# Documentation Considerations
These are hints for the documentation team to help write the docs.
