### PR TITLE
test: add reconnection tests for offline behavior

### DIFF
--- a/cypress/e2e/reconnection.cy.ts
+++ b/cypress/e2e/reconnection.cy.ts
@@ -1,111 +1,105 @@
-import { Server, Client, SocketIO, WebSocket } from 'mock-socket'
+import { Server, Client, SocketIO, WebSocket } from "mock-socket";
 
 const goOffline = () => {
-    cy.log('**go offline**')
-        .then(() => {
-            return Cypress.automation('remote:debugger:protocol',
-                {
-                    command: 'Network.enable',
-                })
-        })
-        .then(() => {
-            return Cypress.automation('remote:debugger:protocol',
-                {
-                    command: 'Network.emulateNetworkConditions',
-                    params: {
-                        offline: true,
-                        latency: -1,
-                        downloadThroughput: -1,
-                        uploadThroughput: -1,
-                    },
-                })
-        })
-}
+	cy.log("**go offline**")
+		.then(() => {
+			return Cypress.automation("remote:debugger:protocol", {
+				command: "Network.enable",
+			});
+		})
+		.then(() => {
+			return Cypress.automation("remote:debugger:protocol", {
+				command: "Network.emulateNetworkConditions",
+				params: {
+					offline: true,
+					latency: -1,
+					downloadThroughput: -1,
+					uploadThroughput: -1,
+				},
+			});
+		});
+};
 
 const goOnline = () => {
-    // disable offline mode, otherwise we will break our tests :)
-    cy.log('**go online**')
-        .then(() => {
-            // https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-emulateNetworkConditions
-            return Cypress.automation('remote:debugger:protocol',
-                {
-                    command: 'Network.emulateNetworkConditions',
-                    params: {
-                        offline: false,
-                        latency: -1,
-                        downloadThroughput: -1,
-                        uploadThroughput: -1,
-                    },
-                })
-        })
-        .then(() => {
-            return Cypress.automation('remote:debugger:protocol',
-                {
-                    command: 'Network.disable',
-                })
-        })
-}
+	// disable offline mode, otherwise we will break our tests :)
+	cy.log("**go online**")
+		.then(() => {
+			// https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-emulateNetworkConditions
+			return Cypress.automation("remote:debugger:protocol", {
+				command: "Network.emulateNetworkConditions",
+				params: {
+					offline: false,
+					latency: -1,
+					downloadThroughput: -1,
+					uploadThroughput: -1,
+				},
+			});
+		})
+		.then(() => {
+			return Cypress.automation("remote:debugger:protocol", {
+				command: "Network.disable",
+			});
+		});
+};
 
 const assertOnline = () => {
-    return cy.wrap(window).its('navigator.onLine').should('be.true')
-}
+	return cy.wrap(window).its("navigator.onLine").should("be.true");
+};
 
 const assertOffline = () => {
-    return cy.wrap(window).its('navigator.onLine').should('be.false')
-}
+	return cy.wrap(window).its("navigator.onLine").should("be.false");
+};
 
 // Offline behavior is not supported in Firefox
-describe('Reconnection', { browser: "!firefox" }, () => {
+describe("Reconnection", { browser: "!firefox" }, () => {
+	beforeEach(() => {
+		goOnline();
+		cy.visit("/webchat.test.html");
+	});
 
-    beforeEach(() => {
-        goOnline();
-        cy.visit("/webchat.test.html")
-    });
+	afterEach(goOnline);
 
-    afterEach(goOnline);
+	it("should send the messages after network reconnection", () => {
+		cy.initWebchat({
+			settings: {
+				homeScreen: {
+					enabled: true,
+					previousConversations: {
+						enabled: true,
+						buttonText: "View previous conversations",
+					},
+				},
+				behavior: {
+					enableConnectionStatusIndicator: false,
+				},
+			},
+		});
 
-    it('should send the messages after network reconnection', () => {
-        cy.initWebchat({
-            settings: {
-                homeScreen: {
-                    enabled: true,
-                    previousConversations: {
-                        enabled: true,
-                        buttonText: "View previous conversations",
-                    },
-                },
-                behavior: {
-                    enableConnectionStatusIndicator: false,
-                }
-            }
-        })
+		// Open Webchat to establish a connection
+		cy.openWebchat();
+		cy.startConversation();
 
-        // Open Webchat to establish a connection
-        cy.openWebchat();
-        cy.startConversation()
+		// Wait until a stable connection is established before going offline
+		cy.waitUntil(() =>
+			cy.get(".webchat-chat-history").contains("You're now chatting with an AI Agent."),
+		);
+		// Go offline
+		goOffline();
 
-        // Wait until a stable connection is established before going offline
-        cy.waitUntil(
-            () => cy.get(".webchat-chat-history").contains("You're now chatting with an AI Agent."),
-        );
-        // Go offline
-        goOffline();
+		assertOffline();
 
-        assertOffline();
+		// Send a  messages
+		cy.get('[aria-label="Message to send"]')
+			.type("Hi")
+			.get('[aria-label="Send Message"]')
+			.click()
+			.get(".webchat-chat-history")
+			.contains("Hi");
 
-        // Send a  messages
-        cy.get('[aria-label="Message to send"]')
-            .type("Hi")
-            .get('[aria-label="Send Message"]')
-            .click()
-            .get(".webchat-chat-history")
-            .contains("Hi");
+		// Wait for the reconnection
+		goOnline();
+		assertOnline();
 
-        // Wait for the reconnection
-        goOnline();
-        assertOnline();
-
-        cy.get(".webchat-chat-history").contains("You said \"Hi\".");
-
-    });
+		cy.get(".webchat-chat-history").contains('You said "Hi".');
+	});
 });

--- a/cypress/e2e/reconnection.cy.ts
+++ b/cypress/e2e/reconnection.cy.ts
@@ -50,7 +50,7 @@ const assertOffline = () => {
 	return cy.wrap(window).its("navigator.onLine").should("be.false");
 };
 
-// Offline behavior is not supported in Firefox
+// remote:debugger:protocol is not supported in Firefox
 describe("Reconnection", { browser: "!firefox" }, () => {
 	beforeEach(() => {
 		goOnline();

--- a/cypress/e2e/reconnection.cy.ts
+++ b/cypress/e2e/reconnection.cy.ts
@@ -1,0 +1,110 @@
+import { Server, Client, SocketIO, WebSocket } from 'mock-socket'
+
+const goOffline = () => {
+    cy.log('**go offline**')
+        .then(() => {
+            return Cypress.automation('remote:debugger:protocol',
+                {
+                    command: 'Network.enable',
+                })
+        })
+        .then(() => {
+            return Cypress.automation('remote:debugger:protocol',
+                {
+                    command: 'Network.emulateNetworkConditions',
+                    params: {
+                        offline: true,
+                        latency: -1,
+                        downloadThroughput: -1,
+                        uploadThroughput: -1,
+                    },
+                })
+        })
+}
+
+const goOnline = () => {
+    // disable offline mode, otherwise we will break our tests :)
+    cy.log('**go online**')
+        .then(() => {
+            // https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-emulateNetworkConditions
+            return Cypress.automation('remote:debugger:protocol',
+                {
+                    command: 'Network.emulateNetworkConditions',
+                    params: {
+                        offline: false,
+                        latency: -1,
+                        downloadThroughput: -1,
+                        uploadThroughput: -1,
+                    },
+                })
+        })
+        .then(() => {
+            return Cypress.automation('remote:debugger:protocol',
+                {
+                    command: 'Network.disable',
+                })
+        })
+}
+
+const assertOnline = () => {
+    return cy.wrap(window).its('navigator.onLine').should('be.true')
+}
+
+const assertOffline = () => {
+    return cy.wrap(window).its('navigator.onLine').should('be.false')
+}
+
+describe('Reconnection', { browser: "!firefox" }, () => {
+
+    beforeEach(() => {
+        goOnline();
+        cy.visit("/webchat.test.html")
+    });
+
+    afterEach(goOnline);
+
+    it('should send the messages after network reconnection', () => {
+        cy.initWebchat({
+            settings: {
+                homeScreen: {
+                    enabled: true,
+                    previousConversations: {
+                        enabled: true,
+                        buttonText: "View previous conversations",
+                    },
+                },
+                behavior: {
+                    enableConnectionStatusIndicator: false,
+                }
+            }
+        })
+
+        // Open Webchat to establish a connection
+        cy.openWebchat();
+        cy.startConversation()
+
+        // Wait until a stable connection is established before going offline
+        cy.waitUntil(
+            () => cy.get(".webchat-chat-history").contains("You're now chatting with an AI Agent."),
+        );
+        // Go offline
+        goOffline();
+
+        assertOffline();
+
+        // Send a  messages
+        cy.get('[aria-label="Message to send"]')
+            .type("Hi")
+            .get('[aria-label="Send Message"]')
+            .click()
+            .get(".webchat-chat-history")
+            .contains("Hi");
+
+        // Wait for the reconnection
+        goOnline();
+        assertOnline();
+
+        cy.get(".webchat-chat-history").contains("You said \"Hi\".");
+
+    });
+});

--- a/cypress/e2e/reconnection.cy.ts
+++ b/cypress/e2e/reconnection.cy.ts
@@ -54,6 +54,7 @@ const assertOffline = () => {
     return cy.wrap(window).its('navigator.onLine').should('be.false')
 }
 
+// Offline behavior is not supported in Firefox
 describe('Reconnection', { browser: "!firefox" }, () => {
 
     beforeEach(() => {


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

-  Re connection e2e suite to test offline->online behavior should run in test pipeline (Only chrome) 

see [ticket](https://cognigy.visualstudio.com/Boron/_workitems/edit/89659)
# How to test

Please describe the individual steps on how a peer can test your change.

1. Expect the e2e chrome pipeline to complete without failing


# Security

-   [ ] Possible injection vector
-   [ ] Authentication/Access controls touched
-   [ ] Sensitive Data could be exposed
-   [ ] XSS
-   [ ] Logging/Monitoring touched
-   [ ] Exchanges data with external systems
-   [x] No security implications

# Additional considerations

-   [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
