### PR TITLE
Removed relative positioning from scrollable chat area

### DIFF
--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -22,6 +22,7 @@ const Scroller = styled(ScrollToBottom)({
 	height: "100% !important",
 	width: "100%",
 	overflowY: "auto" as const,
+	position: "initial",
 
 	"& .hiddenAutoScrollButton": {
 		display: "none",
@@ -38,7 +39,7 @@ const ChatLog = styled.div(({ theme }) => ({
 const ScrollButton = styled("button")(({ theme }) => ({
 	position: "absolute",
 	zIndex: 10,
-	bottom: "20px",
+	bottom: "110px",
 	left: "50%",
 	transform: "translateX(-50%)",
 	backgroundColor: theme.primaryWeakColor,


### PR DESCRIPTION
There is a conflict in positioning relative to the parent container between the opened date picker and the "scroll-to-bottom"-button. This PR removes the relative positioning from the scrollable area that was introduced to position the scroll-button.

see here for how it should look (and looks with this fix):

![Screenshot from 2025-03-04 13-54-02](https://github.com/user-attachments/assets/1f124625-d162-4980-8f9c-5759ffcee883)
![Screenshot from 2025-03-04 13-53-45](https://github.com/user-attachments/assets/4701fc37-3d7e-45f9-9a8c-741016fa5787)


This "fix" now leads to another issue: If the input area grows (due to long text in it) AND the scroll-button is visible, it will be displayed on top of the input area. see screenshot below.

![Screenshot from 2025-03-04 13-53-54](https://github.com/user-attachments/assets/51df0fe6-0c34-4f84-9337-de74fbf8bc82)


# Success criteria

- date picker is positioned correctly when open
- scrollable chat area working as expected (no double scroll bars, overflowing elements etc.)


# How to test

Please describe the individual steps on how a peer can test your change.

1. deploy webchat with date picker
2. make sure there are enough message that chat area is scrolling
3. test for breaking display

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
