### PR TITLE
Bug/87618 fix start behavior with privacy screen

### DIFF
--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -34,6 +34,7 @@ There are several classes that you need to take in consideration if you want to 
 - _webchat-input-button-add-attachments_
 - _webchat-input-drag-and-drop-file-text_
 - _webchat-input-button-send_
+- _webchat-input-get-started-button_
 - _webchat-toggle-button_
 - _webchat-unread-message-preview_
 - _webchat-unread-message-badge_
@@ -384,6 +385,17 @@ The avatars can be repositioned to appear at the top edge of a message rather th
     border-radius: 20px;
     background-color: white;
 
+}
+```
+
+- _webchat-input-get-started-button_  
+  The button to initiate the first interaction in the Webchat. You can customize its appearance, size, and background.
+
+```CSS
+[data-cognigy-webchat-root] [data-cognigy-webchat].webchat .webchat-input-get-started-button {
+
+    border-radius: 10px;
+    background-color: rgb(0, 123, 255);
 }
 ```
 

--- a/src/plugins/get-started-button-input/GetStartedInput.tsx
+++ b/src/plugins/get-started-button-input/GetStartedInput.tsx
@@ -7,11 +7,6 @@ import styled from "@emotion/styled";
 const GetStartedButton = styled(Button)(({ theme }) => ({
 	marginBottom: theme.unitSize * 2,
 	flexGrow: 1,
-	"&:focus": {
-		outline: "none",
-		boxShadow: `0 0 3px 1px ${theme.primaryWeakColor}`,
-		backgroundColor: theme.primaryStrongColor,
-	},
 }));
 
 const GetStartedInput = ({ onSendMessage, config }: InputComponentProps) => (
@@ -26,6 +21,7 @@ const GetStartedInput = ({ onSendMessage, config }: InputComponentProps) => (
 			}
 			color="primary"
 			id="webchatGetStartedButton"
+			className="webchat-input-get-started-button"
 		>
 			{config.settings.startBehavior.getStartedButtonText}
 		</GetStartedButton>

--- a/src/plugins/get-started-button-input/index.ts
+++ b/src/plugins/get-started-button-input/index.ts
@@ -1,6 +1,7 @@
 import GetStartedInput from "./GetStartedInput";
 import { InputRule, InputPlugin } from "../../common/interfaces/input-plugin";
 import { registerInputPlugin } from "../helper";
+import getMessagesListWithoutControlCommands from "../../webchat-ui/utils/filter-out-control-commands";
 
 const rule: InputRule = ({
 	config: {
@@ -16,14 +17,16 @@ const rule: InputRule = ({
 	},
 	messages,
 }) =>
-	(messages.length === 0 || (messages.length === 1 && messages[0].source === "engagement")) &&
-	startBehavior === "button" &&
-	!!getStartedPayload &&
-	(!!getStartedButtonText ||
-		!!getStartedText ||
-		(!!getStartedData &&
-			typeof getStartedData === "object" &&
-			Object.keys(getStartedData).length > 0));
+	messages.length === 0 ||
+	(messages.length === 1 && messages[0].source === "engagement") ||
+	(getMessagesListWithoutControlCommands(messages)?.length === 0 &&
+		startBehavior === "button" &&
+		!!getStartedPayload &&
+		(!!getStartedButtonText ||
+			!!getStartedText ||
+			(!!getStartedData &&
+				typeof getStartedData === "object" &&
+				Object.keys(getStartedData).length > 0)));
 
 const getStartedInputPlugin: InputPlugin = {
 	type: "rule",

--- a/src/plugins/get-started-button-input/index.ts
+++ b/src/plugins/get-started-button-input/index.ts
@@ -17,16 +17,16 @@ const rule: InputRule = ({
 	},
 	messages,
 }) =>
-	messages.length === 0 ||
-	(messages.length === 1 && messages[0].source === "engagement") ||
-	(getMessagesListWithoutControlCommands(messages)?.length === 0 &&
-		startBehavior === "button" &&
-		!!getStartedPayload &&
-		(!!getStartedButtonText ||
-			!!getStartedText ||
-			(!!getStartedData &&
-				typeof getStartedData === "object" &&
-				Object.keys(getStartedData).length > 0)));
+	(messages.length === 0 ||
+		(messages.length === 1 && messages[0].source === "engagement") ||
+		getMessagesListWithoutControlCommands(messages)?.length === 0) &&
+	startBehavior === "button" &&
+	!!getStartedPayload &&
+	(!!getStartedButtonText ||
+		!!getStartedText ||
+		(!!getStartedData &&
+			typeof getStartedData === "object" &&
+			Object.keys(getStartedData).length > 0));
 
 const getStartedInputPlugin: InputPlugin = {
 	type: "rule",

--- a/src/webchat/store/autoinject/autoinject-middleware.ts
+++ b/src/webchat/store/autoinject/autoinject-middleware.ts
@@ -61,7 +61,7 @@ export const createAutoInjectMiddleware =
 				// except if explicitly set via enableInjectionWithoutEmptyHistory
 				if (!config.settings.widgetSettings.enableInjectionWithoutEmptyHistory) {
 					// If there are stored messages waiting to be sent, don't send the auto-inject message
-					if(state.ui.storedMessage) {
+					if (state.ui.storedMessage) {
 						break;
 					}
 

--- a/src/webchat/store/autoinject/autoinject-middleware.ts
+++ b/src/webchat/store/autoinject/autoinject-middleware.ts
@@ -58,8 +58,13 @@ export const createAutoInjectMiddleware =
 				}
 
 				// Don't trigger the auto inject message when the history is not empty
-				// except if explicitly set via enableAutoInjectWithHistory
+				// except if explicitly set via enableInjectionWithoutEmptyHistory
 				if (!config.settings.widgetSettings.enableInjectionWithoutEmptyHistory) {
+					// If there are stored messages waiting to be sent, don't send the auto-inject message
+					if(state.ui.storedMessage) {
+						break;
+					}
+
 					// Exclude engagement messages from state.messages
 					const messagesExcludingEngagementMessages = state.messages?.filter(
 						message => message.source !== "engagement",

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -67,7 +67,6 @@ export const createConnectionMiddleware =
 								store.dispatch(setStoredMessage(null));
 							}
 							store.dispatch(setOptions(client.socketOptions));
-
 						})
 						.catch(() => {
 							store.dispatch(setConnecting(false));

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -56,7 +56,6 @@ export const createConnectionMiddleware =
 							// set options
 							store.dispatch(setConnecting(false));
 							store.dispatch(setReconnectionLimit(false));
-							store.dispatch(setOptions(client.socketOptions));
 
 							if (storedMessage) {
 								store.dispatch(
@@ -67,6 +66,8 @@ export const createConnectionMiddleware =
 								);
 								store.dispatch(setStoredMessage(null));
 							}
+							store.dispatch(setOptions(client.socketOptions));
+
 						})
 						.catch(() => {
 							store.dispatch(setConnecting(false));


### PR DESCRIPTION
# Success criteria

- The 'Start with a button' behavior should display the get started button even in the presence of privacy screen
- Clicking conversation starter in home screen or teaser message when 'Auto send message to bot' start behavior is configured should not behave differently with and without privacy screen
- The order in which the conversation starter and get started message is sent when 'enableInjectionWithoutEmptyHistory' is true should be same with and without privacy screen. 
- Focus style of Get started button is consistent with rest of the buttons in v3


# How to test

Test 1:
    - Enable Privacy Notice
    - Configure the start behavior to 'Start with a button'
    - Now open the webchat and accept the privacy notice. After this, a chat screen with a button should be shown. 

Test 2: 
    - Enable Privacy notice
    - Configure the start behavior to 'Auto send message to bot'
    - Enable Home screen and add some conversation starters
    - Now open webchat and click on the conversation starter in the home screen. 
    - Accept the privacy screen that is shown. After this only conversation starter message should be sent in the chat (The chat should work in the same way even when there is no privacy screen)
    - Repeat the same test by configuring teaser message with conversation starters and test the conversation starter button clicks with and without privacy screen

Test 3:
    - Enable Privacy notice
    - Configure the start behavior to 'Auto send message to bot'
    - Enable Home screen and add some conversation starters
    - Set enableInjectionWithoutEmptyHistory to true
    - Now open webchat and click on the conversation starter in the home screen. 
    - Accept the privacy screen that is shown. After this conversation starter message should be sent followed by get started message (The chat should work in the same way even when there is no privacy screen)
    - Repeat the same test by configuring teaser message with conversation starters and test the conversation starter button clicks with and without privacy screen

Test 4:
    - Configure the start behavior to 'Start with a button'
    - Focus the button using keyboard. The focus style should be same as the 'Start conversation' button in the home screen.


# Security

- [x] No security implications


# Documentation Considerations

None