### PR TITLE
Fix dropzone visibility

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1238,12 +1238,9 @@ export class WebchatUI extends React.PureComponent<
 		const handleDragEnter = e => {
 			e.preventDefault();
 			e.stopPropagation();
-
-			this.props.onSetDropZoneVisible(true);
-		};
-
-		const handleDropZoneVisibility = (isDropZoneVisible: boolean) => {
-			this.props.onSetDropZoneVisible(isDropZoneVisible);
+			if (config?.settings?.fileStorageSettings?.enabled) {
+				this.props.onSetDropZoneVisible(true);
+			}
 		};
 
 		const getRegularLayoutContent = () => {


### PR DESCRIPTION
This pull request includes a minor update to the `WebchatUI` component in the `src/webchat-ui/components/WebchatUI.tsx` file. The change ensures that the drop zone visibility is only set when the file storage settings are enabled.

* [`src/webchat-ui/components/WebchatUI.tsx`](diffhunk://#diff-3e22c3aa55508da4a4df11f22a9ad94f2d4721318ec54fdd8de8f66136858ad7L1241-R1243): Updated `handleDragEnter` to check if `config?.settings?.fileStorageSettings?.enabled` is true before calling `this.props.onSetDropZoneVisible(true)`.

# Success criteria

- When dragging a file into Webchat, we show the drop zone only when the file upload is configured.

# How to test

1. Disable file upload in the endpoint 
Webchat3 -> Webchat behavior -> Attachment Upload -> Enabled: false
2. Try to drag a file into the Webchat. Drop zone should not be activated.
3. Enable file upload setting
4. Try to drag a file in.
5. Drop zone should become visible.