### PR TITLE
Fix "Unread Messages" Indicator

### DIFF
--- a/src/webchat/store/ui/ui-middleware.ts
+++ b/src/webchat/store/ui/ui-middleware.ts
@@ -39,8 +39,10 @@ export const uiMiddleware: Middleware<object, StoreState> =
 			case "SET_OPEN": {
 				const { open } = action;
 
+				// We determine if the chat history is visible by other screens visibility.
 				const { showHomeScreen, showPrevConversations, showChatOptionsScreen } =
 					store.getState().ui;
+
 				const isChatHistoryVisible =
 					!showPrevConversations && !showChatOptionsScreen && !showHomeScreen;
 

--- a/src/webchat/store/ui/ui-middleware.ts
+++ b/src/webchat/store/ui/ui-middleware.ts
@@ -7,6 +7,7 @@ import {
 	ShowChatScreenAction,
 	SetPageVisibleAction,
 	SetHasAcceptedTermsAction,
+	SetOpenAction,
 } from "./ui-reducer";
 import { getStorage } from "../../helper/storage";
 import { setHasAcceptedTermsInStorage } from "../../helper/privacyPolicy";
@@ -17,6 +18,7 @@ export const uiMiddleware: Middleware<object, StoreState> =
 	(
 		action:
 			| ToggleOpenAction
+			| SetOpenAction
 			| ShowChatScreenAction
 			| SetPageVisibleAction
 			| SetHasAcceptedTermsAction,
@@ -30,6 +32,21 @@ export const uiMiddleware: Middleware<object, StoreState> =
 				const open = store.getState().ui.open;
 
 				store.dispatch(setOpen(!open));
+
+				break;
+			}
+
+			case "SET_OPEN": {
+				const open = action.open;
+
+				const { showHomeScreen, showPrevConversations, showChatOptionsScreen } =
+					store.getState().ui;
+				const isChatHistoryVisible =
+					!showPrevConversations && !showChatOptionsScreen && !showHomeScreen;
+
+				if (open && isChatHistoryVisible) {
+					store.dispatch(clearUnseenMessages());
+				}
 
 				break;
 			}

--- a/src/webchat/store/ui/ui-middleware.ts
+++ b/src/webchat/store/ui/ui-middleware.ts
@@ -37,7 +37,7 @@ export const uiMiddleware: Middleware<object, StoreState> =
 			}
 
 			case "SET_OPEN": {
-				const open = action.open;
+				const { open } = action;
 
 				const { showHomeScreen, showPrevConversations, showChatOptionsScreen } =
 					store.getState().ui;


### PR DESCRIPTION
Implemented the `SET_OPEN` case in the `uiMiddleware` function to clear unseen messages when the chat is opened and chat history is visible immidiately as it was a missing peace of the logic. Other scenarios were handled well.


# Success criteria

- When opening the Webchat with messages, the unread message indicator should go away.

# How to test

1. Init with these settings:
```
unreadMessages: {
    enableIndicator: true,
    enableBadge: true,
    enablePreview: true,
    enableSound: true,
},
```
2. Talk to a bot and press the Webchat toggle button before the messages arrive.
3. Indicator should eventually appear.
4. Click the toggle button again.
5. Indicator should dissapear when chat history opens.