### PR TITLE
Feature/91152 accessibility fixes part2

### DIFF
--- a/cypress/e2e/chatLog.cy.ts
+++ b/cypress/e2e/chatLog.cy.ts
@@ -7,8 +7,9 @@ describe("Chat Log", () => {
 		cy.get("#webchatChatHistoryWrapperLiveLogPanel").should("have.attr", "tabindex", -1);
 	});
 
-	it.only("is chat log region focusable when the log is scrollable", () => {
+	it("is chat log region focusable when the log is scrollable", () => {
 		cy.withMessageFixture("adaptivecard", () => {
+			cy.get("#webchatChatHistoryWrapperLiveLogPanel").focus();
 			cy.get("#webchatChatHistoryWrapperLiveLogPanel").should("have.attr", "tabindex", 0);
 		});
 	});

--- a/src/webchat-ui/components/Modal/DeleteConfirmModal.tsx
+++ b/src/webchat-ui/components/Modal/DeleteConfirmModal.tsx
@@ -6,10 +6,10 @@ import { getTextContrastColor, deriveHoverColor } from "../../style";
 import SecondaryButton from "../presentational/SecondaryButton";
 
 export const DeleteButton = styled(Button)<{ background?: string }>(({ theme, background }) => ({
-	background: background ? background : theme.red20,
-	color: getTextContrastColor(background ? background : theme.red20, theme),
+	background: background ? background : theme.red30,
+	color: getTextContrastColor(background ? background : theme.red30, theme),
 	"&:hover:not(:disabled)": {
-		background: deriveHoverColor(background ? background : theme.red20),
+		background: deriveHoverColor(background ? background : theme.red30),
 	},
 }));
 
@@ -19,7 +19,7 @@ const CancelButton = styled(SecondaryButton)<{ background?: string }>(({ theme, 
 	marginRight: "auto",
 }));
 
-const DeleteConfirmation = styled(DeleteButton)(({ theme }) => ({
+const DeleteConfirmation = styled(DeleteButton)(() => ({
 	marginLeft: "auto",
 }));
 

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -120,7 +120,6 @@ export interface WebchatUIProps {
 	onSetShowHomeScreen: (show: boolean) => void;
 
 	sttActive: boolean;
-	textActive: boolean;
 	isDropZoneVisible: boolean;
 	onSetDropZoneVisible: (isVisible: boolean) => void;
 	fileList: IFile[];
@@ -724,7 +723,6 @@ export class WebchatUI extends React.PureComponent<
 				onEmitAnalytics={this.props.onEmitAnalytics}
 				theme={this.state.theme}
 				sttActive={this.props.sttActive}
-				textActive={this.props.textActive}
 			/>
 		);
 	};

--- a/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
@@ -12,6 +12,7 @@ import { IWebchatTheme } from "../../style";
 import IconButton from "../presentational/IconButton";
 import Branding from "../branding/Branding";
 import classnames from "classnames";
+import { useSelector } from "../../../webchat/helper/useSelector";
 
 type HTMLDivPropsWithoutInputMode = Omit<React.HTMLProps<HTMLDivElement>, "inputMode">;
 
@@ -22,7 +23,6 @@ export interface InputProps extends InputComponentProps, HTMLDivPropsWithoutInpu
 	inputMode: string;
 	webchatTheme: IWebchatTheme;
 	sttActive: boolean;
-	textActive: boolean;
 }
 
 const SmallToolbar = styled(Toolbar)({
@@ -70,10 +70,10 @@ const InputPluginRenderer = ({
 	webchatTheme,
 	onEmitAnalytics,
 	sttActive,
-	textActive,
 	...props
 }: InputProps): JSX.Element => {
-	const results: any[] = [];
+
+	const textActive = useSelector((state) => state.input.textActive);
 
 	const attributes = Object.keys(props).length > 0 ? props : undefined;
 

--- a/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
@@ -72,8 +72,7 @@ const InputPluginRenderer = ({
 	sttActive,
 	...props
 }: InputProps): JSX.Element => {
-
-	const textActive = useSelector((state) => state.input.textActive);
+	const textActive = useSelector(state => state.input.textActive);
 
 	const attributes = Object.keys(props).length > 0 ? props : undefined;
 

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -78,7 +78,7 @@ const Button = styled.button(({ theme }) => ({
 	},
 	"&:focus-visible": {
 		outline: `2px solid ${theme.primaryColor}`,
-	}	
+	},
 }));
 
 const iconButtonStyles = {

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -61,6 +61,7 @@ const Button = styled.button(({ theme }) => ({
 	padding: 0,
 	backgroundColor: "transparent",
 	border: "none",
+	borderRadius: 4,
 	fill: theme.textDark,
 	cursor: "pointer",
 	outline: "none",
@@ -69,10 +70,15 @@ const Button = styled.button(({ theme }) => ({
 		fill: theme.black60,
 		cursor: "default",
 	},
-
+	"&:not(:disabled):hover": {
+		fill: theme.primaryColor,
+	},
 	"&:focus": {
 		fill: theme.primaryColor,
 	},
+	"&:focus-visible": {
+		outline: `2px solid ${theme.primaryColor}`,
+	}	
 }));
 
 const iconButtonStyles = {
@@ -88,14 +94,6 @@ const MenuButton = styled(Button)<{ open: boolean }>(({ theme, open }) => ({
 	...iconButtonStyles,
 	padding: "6px",
 	fill: open ? theme.primaryColor : "initial",
-	":focus-visible": {
-		outline: `2px solid ${theme.primaryColor}`,
-	},
-	":hover": {
-		svg: {
-			fill: theme.primaryColor,
-		},
-	},
 }));
 
 const AttachFileButton = styled(Button)(() => iconButtonStyles);
@@ -144,7 +142,7 @@ const HiddenFileInput = styled.input(() => ({
 	display: "none",
 }));
 
-const SubmitButton = styled(Button)(() => iconButtonStyles);
+const SendMessageButton = styled(Button)(() => iconButtonStyles);
 
 export interface TextInputState {
 	text: string;
@@ -605,7 +603,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 									</SpeechButton>
 								)}
 
-								<SubmitButton
+								<SendMessageButton
 									disabled={
 										(this.state.text === "" && isFileListEmpty) ||
 										fileUploadError
@@ -618,7 +616,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 									id="webchatInputMessageSendMessageButton"
 								>
 									<SendIcon />
-								</SubmitButton>
+								</SendMessageButton>
 							</>
 						)}
 					</InputForm>

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -14,11 +14,11 @@ import MediaQuery from "react-responsive";
 import PersistentMenu from "../menu/PersistentMenu";
 import { IPersistentMenuItem } from "../../../../../common/interfaces/webchat-config";
 
-const InputWrapper = styled.div(() => ({
+const InputWrapper = styled.div({
 	display: "flex",
 	flexDirection: "column",
 	gap: 12,
-}));
+});
 
 const InputForm = styled.form<{ persistentMenuOpen: boolean }>(({ persistentMenuOpen }) => ({
 	display: "flex",
@@ -98,7 +98,7 @@ const MenuButton = styled(Button)<{ open: boolean }>(({ theme, open }) => ({
 	},
 }));
 
-const AttachFileButton = styled(Button)(({ theme }) => iconButtonStyles);
+const AttachFileButton = styled(Button)(() => iconButtonStyles);
 
 const SpeechButton = styled(Button)(({ theme }) => ({
 	...iconButtonStyles,
@@ -109,9 +109,9 @@ const SpeechButton = styled(Button)(({ theme }) => ({
 	},
 }));
 
-const SpeechIcon = styled(SpeechIconSVG)(() => ({
+const SpeechIcon = styled(SpeechIconSVG)({
 	position: "relative",
-}));
+});
 
 const SpeechButtonBackground = styled.div(({ theme }) => ({
 	position: "absolute",
@@ -144,7 +144,7 @@ const HiddenFileInput = styled.input(() => ({
 	display: "none",
 }));
 
-const SubmitButton = styled(Button)(({ theme }) => iconButtonStyles);
+const SubmitButton = styled(Button)(() => iconButtonStyles);
 
 export interface TextInputState {
 	text: string;
@@ -167,7 +167,6 @@ interface IBaseInputState extends TextInputState, ISpeechInputState, IPersistent
 interface IBaseInputProps extends InputComponentProps {
 	sttActive: boolean;
 	onSetSTTActive: (active: boolean) => void;
-	textActive: boolean;
 	onSetTextActive: (active: boolean) => void;
 	fileUploadError: boolean;
 	fileList: IFile[];
@@ -469,7 +468,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 	render() {
 		const { props, state } = this;
 
-		const { sttActive, fileUploadError, fileList, textActive } = props;
+		const { sttActive, fileUploadError, fileList } = props;
 
 		const { text, speechResult: speechInterim, isMenuOpen } = state;
 
@@ -491,7 +490,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 
 		return (
 			<>
-				<InputWrapper data-active={textActive && isFileListEmpty}>
+				<InputWrapper>
 					<InputForm
 						onSubmit={this.handleSubmit}
 						className={classnames("webchat-input-menu-form")}

--- a/src/webchat-ui/components/plugins/input/base/ConnectedBaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/ConnectedBaseInput.tsx
@@ -13,7 +13,6 @@ import { addFilesToList } from "../../../../../webchat/store/input/file-input-mi
 
 export const ConnectedBaseInput = (props: InputComponentProps) => {
 	const sttActive = useSelector((state: StoreState) => state.input.sttActive);
-	const textActive = useSelector((state: StoreState) => state.input.textActive);
 	const fileList = useSelector((state: StoreState) => state.input.fileList);
 	const fileUploadError = useSelector((state: StoreState) => state.input.fileUploadError);
 
@@ -24,7 +23,6 @@ export const ConnectedBaseInput = (props: InputComponentProps) => {
 			{...props}
 			sttActive={sttActive}
 			onSetSTTActive={(active: boolean) => dispatch(setSTTActive(active))}
-			textActive={textActive}
 			onSetTextActive={(active: boolean) => dispatch(setTextActive(active))}
 			fileList={fileList}
 			fileUploadError={fileUploadError}

--- a/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
+++ b/src/webchat-ui/components/plugins/input/menu/PersistentMenu.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { IPersistentMenuItem } from "../../../../../common/interfaces/webchat-config";
 import styled from "@emotion/styled";
-import { ActionButtons } from "@cognigy/chat-components";
+import { ActionButtons, Typography } from "@cognigy/chat-components";
 import { IWebchatButton } from "@cognigy/socket-client";
 
 interface PersistentMenuProps {
@@ -30,12 +30,6 @@ const ActionButtonsWrapper = styled.div(({ theme }) => ({
 	paddingLeft: theme.unitSize,
 }));
 
-const PersistentMenuTitle = styled.h5(({ theme }) => ({
-	color: "hsla(0, 0%, 0%, .3)",
-	padding: `0 ${theme.unitSize}px ${theme.unitSize}px`,
-	margin: 0,
-}));
-
 const PersistentMenu: React.FC<PersistentMenuProps> = ({ title, menuItems, onSelect }) => {
 	const menuRef = React.useRef<HTMLDivElement>(null);
 
@@ -53,7 +47,7 @@ const PersistentMenu: React.FC<PersistentMenuProps> = ({ title, menuItems, onSel
 						menuRef.current.lastChild) as HTMLButtonElement;
 				break;
 			case "ArrowDown":
-				newFocusTarget = (target.nextElementSibling ||
+				newFocusTarget = ((target as HTMLElement).nextElementSibling ||
 					menuRef.current.firstChild) as HTMLButtonElement;
 				break;
 			case "Home":
@@ -80,7 +74,9 @@ const PersistentMenu: React.FC<PersistentMenuProps> = ({ title, menuItems, onSel
 
 	return (
 		<PersistentMenuContainer className="webchat-input-persistent-menu" tabIndex={-1}>
-			<PersistentMenuTitle>{title}</PersistentMenuTitle>
+			<Typography variant="body-semibold" component="h3" marginTop={4} marginLeft={8}>
+				{title}
+			</Typography>
 			<ActionButtonsWrapper
 				aria-labelledby="persistentMenuTitle"
 				role="menu"

--- a/src/webchat-ui/components/presentational/Header.tsx
+++ b/src/webchat-ui/components/presentational/Header.tsx
@@ -172,7 +172,7 @@ const Header: FC<HeaderProps> = props => {
 							<Logo
 								src={logoUrl}
 								className={classnames("webchat-header-logo")}
-								alt="Chat logo"
+								alt=""
 							/>
 						) : (
 							<CognigyAIAvatar

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -224,7 +224,7 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 						<Logo
 							src={config?.settings?.layout?.logoUrl}
 							className={"webchat-homescreen-header-logo"}
-							alt="Chat logo"
+							alt=""
 						/>
 					) : (
 						<CognigyAIAvatar className={"webchat-homescreen-header-cognigy-logo"} />

--- a/src/webchat-ui/components/presentational/TeaserMessage.tsx
+++ b/src/webchat-ui/components/presentational/TeaserMessage.tsx
@@ -126,10 +126,10 @@ export const TeaserMessage = (props: ITeaserMessageProps) => {
 						<HeaderLogo
 							src={config?.settings?.layout?.logoUrl}
 							className={"webchat-teaser-message-header-logo"}
-							alt="Chat logo"
+							alt=""
 						/>
 					) : (
-						<CognigyAIAvatar alt="Chat logo" />
+						<CognigyAIAvatar alt="" />
 					)}
 					<TeaserMessageHeaderContent>
 						<Typography

--- a/src/webchat-ui/components/presentational/chat-options/ChatOptions.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/ChatOptions.tsx
@@ -12,25 +12,25 @@ import getKeyboardFocusableElements from "../../../utils/find-focusable";
 import TTSOption from "./TTSOption";
 import DeleteConversation from "./DeleteConversation";
 
-const ChatOptionsRoot = styled.div(() => ({
+const ChatOptionsRoot = styled.div({
 	width: "100%",
 	height: "100%",
 	display: "flex",
 	flexDirection: "column",
-}));
+});
 
-const ChatOptionsContainer = styled.div(() => ({
+const ChatOptionsContainer = styled.div({
 	width: "100%",
 	height: "100%",
 	display: "flex",
 	padding: "0 20px",
 	flexDirection: "column",
 	overflowY: "auto",
-}));
+});
 
-const DividerWrapper = styled.div(() => ({
+const DividerWrapper = styled.div({
 	padding: "12px 0px",
-}));
+});
 
 const Divider = styled.div(({ theme }) => ({
 	height: 1,

--- a/src/webchat-ui/components/presentational/chat-options/ChatOptionsFooter.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/ChatOptionsFooter.tsx
@@ -18,9 +18,14 @@ const Link = styled.a(({ theme }) => ({
 	textDecoration: "none",
 	color: theme.black10,
 
-	"&:focus": {
+	"&:focus, &:hover": {
 		outline: "none",
-		color: theme.primaryWeakColor,
+		color: theme.primaryColor,
+	},
+
+	"&:focus-visible": {
+		outline: `2px solid ${theme.primaryColor}`,
+		outlineOffset: 2,
 	},
 }));
 

--- a/src/webchat-ui/components/presentational/chat-options/ChatOptionsFooter.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/ChatOptionsFooter.tsx
@@ -24,11 +24,11 @@ const Link = styled.a(({ theme }) => ({
 	},
 }));
 
-const StyledFooterTypography = styled(Typography)(() => ({
+const StyledFooterTypography = styled(Typography)({
 	lineHeight: "19.6px",
 	wordWrap: "break-word",
 	margin: 0,
-}));
+});
 
 interface IChatOptionsFooterProps {
 	settings: IWebchatSettings;

--- a/src/webchat-ui/components/presentational/chat-options/DeleteConversation.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/DeleteConversation.tsx
@@ -14,15 +14,15 @@ import DeleteConfirmModal, {
 import { switchSession } from "../../../../webchat/store/previous-conversations/previous-conversations-middleware";
 import { getOptionsKey } from "../../../../webchat/store/options/options";
 
-const Container = styled.div`
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	> button {
-		width: auto;
-		padding: 0 16px;
-	}
-`;
+const Container = styled.div({
+	display: "flex",
+	flexDirection: "column",
+	alignItems: "flex-start",
+	"& > button": {
+		width: "auto",
+		padding: "0 16px",
+	},
+});
 
 const DeleteButton = styled(ConfirmDeleteButton)``;
 

--- a/src/webchat-ui/components/presentational/chat-options/PostbackButtons.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/PostbackButtons.tsx
@@ -5,16 +5,16 @@ import { IWebchatConfig } from "../../../../common/interfaces/webchat-config";
 import { WebchatUIProps } from "../../WebchatUI";
 import { IWebchatButton } from "@cognigy/socket-client";
 
-const PostbackButtonsRoot = styled.div(() => ({
+const PostbackButtonsRoot = styled.div({
 	display: "flex",
 	flexDirection: "column",
 	alignItems: "flex-start",
 	gap: 24,
 	alignSelf: "stretch",
 	padding: "20px 0",
-}));
+});
 
-const ActionButtonsWrapper = styled.div(() => ({
+const ActionButtonsWrapper = styled.div({
 	display: "flex",
 	width: "295px",
 	flexDirection: "row",
@@ -22,7 +22,7 @@ const ActionButtonsWrapper = styled.div(() => ({
 	alignItems: "flex-end",
 	alignContent: "flex-end",
 	gap: 8,
-}));
+});
 
 interface IPostbackButtonsProps {
 	config: IWebchatConfig;

--- a/src/webchat-ui/components/presentational/chat-options/RatingWidget.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/RatingWidget.tsx
@@ -10,21 +10,21 @@ import MultilineInput from "../MultilineInput";
 import { IOnSendRatingProps } from "./ChatOptions";
 import { useSelector } from "../../../../webchat/helper/useSelector";
 
-const RatingWidgetRoot = styled.div(() => ({
+const RatingWidgetRoot = styled.div({
 	width: "100%",
 	height: "310px",
 	display: "flex",
 	flexDirection: "column",
 	padding: "20px 0",
 	gap: 24,
-}));
+});
 
-const RatingButtonContainer = styled.div(() => ({
+const RatingButtonContainer = styled.div({
 	width: "100%",
 	display: "flex",
 	alignItems: "flex-start",
 	gap: 8,
-}));
+});
 
 const RatingButton = styled(IconButton)(({ theme, selected }) => ({
 	background: selected ? theme.primaryColor : theme.black95,
@@ -56,14 +56,14 @@ const RatingDownIcon = styled(RatingDown)(({ theme, selected }) => ({
 	},
 }));
 
-const RatingTextContainer = styled.div(() => ({
+const RatingTextContainer = styled.div({
 	display: "flex",
 	flexDirection: "column",
 	justifyContent: "center",
 	alignItems: "flex-start",
 	gap: 16,
 	alignSelf: "stretch",
-}));
+});
 
 const SendButton = styled(PrimaryButton)(({ theme }) => ({
 	width: "100%",

--- a/src/webchat-ui/components/presentational/chat-options/RatingWidget.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/RatingWidget.tsx
@@ -119,8 +119,8 @@ export const RatingWidget = (props: IRatingWidgetProps) => {
 		<RatingWidgetRoot className="webchat-rating-widget-root">
 			<Typography
 				variant="title1-semibold"
-				component="div"
 				className="webchat-rating-widget-title"
+				margin={0}
 			>
 				{ratingTitleText}
 			</Typography>

--- a/src/webchat-ui/style.ts
+++ b/src/webchat-ui/style.ts
@@ -45,6 +45,7 @@ export interface IWebchatTheme {
 	red: string;
 	red10: string;
 	red20: string;
+	red30: string;
 	red40: string;
 
 	// Legacy Webchat V2 theme colors
@@ -174,6 +175,7 @@ export const createWebchatTheme = (
 	const red = "#FF0000";
 	const red10 = "#FFE5E5";
 	const red20 = "#E55050";
+	const red30 = "#E02E2E";
 	const red40 = "#B22F2F";
 
 	// calculate new gradient based on optional theme.primaryColor if no theme.backgroundHome is given
@@ -274,6 +276,8 @@ export const createWebchatTheme = (
 	if (!theme.red10) theme.red10 = red10;
 
 	if (!theme.red20) theme.red20 = red20;
+
+	if (!theme.red30) theme.red30 = red30;
 
 	if (!theme.red40) theme.red40 = red40;
 

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -94,7 +94,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
 				requestRatingEventBannerText,
 				requestRatingChatStatusBadgeText,
 			},
-			input: { sttActive, textActive, isDropZoneVisible, fileList, fileUploadError },
+			input: { sttActive, isDropZoneVisible, fileList, fileUploadError },
 			xAppOverlay: { open: isXAppOverlayOpen },
 		} = state;
 
@@ -121,7 +121,6 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
 			requestRatingChatStatusBadgeText,
 			showHomeScreen,
 			sttActive,
-			textActive,
 			isDropZoneVisible,
 			fileList,
 			fileUploadError,


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- Input icon buttons like send, speech to text, file attachment, persistent menu icons should have a focus outline.
- Chat options footer links also has a visible focus outline
- Chat Options rating section title uses h3
- Delete button background and text has a contrast ration of at least 4.5:1.
- Persistent menu title text color has enough contrast and uses h3 instead of h5
- Focus is not lost when reverse navigating from input field to the chat log interactive elements

# How to test

Please describe the individual steps on how a peer can test your change.

1. Test the keyboard focus styles for icon buttons mentioned in the success criteria.
2. Check the focus style of Chat options footer links
3. Check the contrast ratio of the Delete button background and text using a contrast checker. For example: https://webaim.org/resources/contrastchecker/
4. Check the title of rating section in chat options and persistent menu
5. For the last SC, create a flow with a say node of output type quick reply with some buttons. Disable Persistent menu. Chat with the bot. When focus is on input field, click Shift +tab. Now focus should move to the last quick reply button and stay there. (Previously focus did not stay and quickly lost after the button focus)

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
