### PR TITLE
fix:  #96647  file upload handling with cancellation support

### DIFF
--- a/src/webchat/helper/endpoint.ts
+++ b/src/webchat/helper/endpoint.ts
@@ -41,7 +41,12 @@ export const fetchFileUploadToken = async (fileUploadTokenUrl: string) => {
 	return response.json() as IUploadFileToken;
 };
 
-export const uploadFile = async (file: File, fileUploadUrl: string, token: string) => {
+export const uploadFile = async (
+	file: File,
+	fileUploadUrl: string,
+	token: string,
+	signal?: AbortController,
+) => {
 	const axiosRequest: AxiosRequestConfig = {
 		data: { file: file },
 		headers: {
@@ -50,6 +55,7 @@ export const uploadFile = async (file: File, fileUploadUrl: string, token: strin
 		},
 		method: "POST",
 		url: fileUploadUrl,
+		signal: signal ? signal.signal : undefined,
 	};
 	const axiosResponse: AxiosResponse = await Axios(axiosRequest);
 

--- a/src/webchat/store/input/input-reducer.ts
+++ b/src/webchat/store/input/input-reducer.ts
@@ -114,9 +114,9 @@ export const input: Reducer<IInputState, InputAction> = (state = getInitialState
 		}
 
 		case REMOVE_FILE_FROM_LIST: {
-			const fileIem = state.fileList[action.index];
-			if (fileIem?.abortController) {
-				fileIem.abortController.abort();
+			const fileItem = state.fileList[action.index];
+			if (fileItem?.abortController) {
+				fileItem.abortController.abort();
 			}
 			const nextFileList = state.fileList.filter((_, i) => i !== action.index);
 			let fileUploadError = false;

--- a/src/webchat/store/input/input-reducer.ts
+++ b/src/webchat/store/input/input-reducer.ts
@@ -6,7 +6,9 @@ export interface IFile {
 	progressPercentage?: number;
 	uploadFileMeta?: IUploadFileMetaData;
 	hasUploadError?: boolean;
+	isCancelled?: boolean;
 	uploadErrorReason?: string;
+	abortController?: AbortController;
 }
 export interface IInputState {
 	sttActive: boolean;
@@ -112,6 +114,10 @@ export const input: Reducer<IInputState, InputAction> = (state = getInitialState
 		}
 
 		case REMOVE_FILE_FROM_LIST: {
+			const fileIem = state.fileList[action.index];
+			if (fileIem?.abortController) {
+				fileIem.abortController.abort();
+			}
 			const nextFileList = state.fileList.filter((_, i) => i !== action.index);
 			let fileUploadError = false;
 			// When files with upload error is removed, we want to enable the send button


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- Cancelling a file upload should remove the file item from preview
- Cancelled file item should not appear again after few seconds
- The request to upload should be aborted on cancel

# How to test

Please describe the individual steps on how a peer can test your change.

1. Open any webchat with file upload enabled (Set file upload size to 20MB)
2. Click file attach button and upload a 20 MB file
3. Cancel the upload
4. Observe the file item is removed and doesn't appear again
5. Test it with a message and send the message
6. Observe the file is not sent along with the message

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
