### PR TITLE
fix: #97992 update visibility logic for delete all conversations button based on privacy notice acceptance

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1396,6 +1396,8 @@ export class WebchatUI extends React.PureComponent<
 		const hideBackButton = showChatScreen && !isHomeScreenEnabled;
 
 		const showDeleteAllConversationButton = !!(
+			((config.settings.privacyNotice.enabled && this.props.hasAcceptedTerms) ||
+				!config.settings.privacyNotice.enabled) &&
 			config.settings.homeScreen.previousConversations.enableDeleteAllConversations &&
 			showPrevConversations &&
 			Object.keys(this.props.prevConversations).length


### PR DESCRIPTION

# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- The delete all conversations button must not appear in the privacy settings screen


# How to test

Please describe the individual steps on how a peer can test your change.

1. Open a webchat with the following settings
`homeScreen: {
	enabled: true,
	previousConversations: {
		enableDeleteAllConversations: true,
	},
},
privacyNotice: {
	enabled: true,
	text: "This is a privacy notice",
}`
2. Open Previous conversations
3. Observe privacy screen appears without the delete button on the header
4. Now Disable privacy settings
5. Clear your local storage
6. Begin conversation with the bot
7. Enable privacy setting again
8. Open previous conversation
9. Observe privacy screen appears without the delete button on the header

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
