### PR TITLE
Fix/#81782 switch session when close chat is clicked

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,46 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>webchat development</title>
+	</head>
 
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>webchat development</title>
-</head>
-
-<body>
-    <script src="./webchat.js"></script>
-    <script>
-            initWebchat('https://endpoint-dev.cognigy.ai/896f0112910ff0755a529b4dcb1622aeaf9931e516b52e8528603ad10d879661', {
-            // userId: "user1",
-            // sessionId: "session1",
-            settings: {
-                layout: {
-                    watermark: "default",
-                    watermarkText: "Some Random Watermark"
-                },
-                unreadMessages: {
-                    enableIndicator: true,
-                    enableBadge: true,  
-                    enablePreview: true,
-                    enableSound: true
-                },
-                teaserMessage:{
-                    showInChat: true,
-                    teaserMessageDelay: 5000,
-                    text: "Hi there!"
-                    },
-                startBehavior: {
-                    getStartedText: ""
-                },
-                widgetSettings: {
-                    enableFocusTrap: true,
-                }
-            },
-        }).then(function (webchat) {
-            window.cognigyWebchat = webchat;
-            // webchat.open();
-			// webchat.startConversation();
-        })
-    </script>
-</body>
-
+	<body>
+		<script src="./webchat.js"></script>
+		<script>
+			initWebchat(
+				"https://endpoint-dev.cognigy.ai/7992a50f6fa7c93d5d8bd27cf5a76f628fda6feae7c581fbac7d751dc86f83eb",
+				{
+					settings: {
+						layout: {
+							watermark: "default",
+							watermarkText: "Some Random Watermark",
+						},
+						unreadMessages: {
+							enableIndicator: true,
+							enableBadge: true,
+							enablePreview: true,
+							enableSound: true,
+						},
+						teaserMessage: {
+							showInChat: true,
+							teaserMessageDelay: 5000,
+							text: "Hi there!",
+						},
+						startBehavior: {
+							getStartedText: "",
+						},
+						widgetSettings: {
+							enableFocusTrap: true,
+						},
+					},
+				},
+			).then(function (webchat) {
+				window.cognigyWebchat = webchat;
+				// webchat.open();
+				// webchat.startConversation();
+				window.cognigyWebchat.registerAnalyticsService(event => {
+					if (event.type === "webchat/close") {
+						webchat.endSession();
+					}
+				});
+			});
+		</script>
+	</body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,50 +1,46 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>webchat development</title>
-	</head>
 
-	<body>
-		<script src="./webchat.js"></script>
-		<script>
-			initWebchat(
-				"https://endpoint-dev.cognigy.ai/7992a50f6fa7c93d5d8bd27cf5a76f628fda6feae7c581fbac7d751dc86f83eb",
-				{
-					settings: {
-						layout: {
-							watermark: "default",
-							watermarkText: "Some Random Watermark",
-						},
-						unreadMessages: {
-							enableIndicator: true,
-							enableBadge: true,
-							enablePreview: true,
-							enableSound: true,
-						},
-						teaserMessage: {
-							showInChat: true,
-							teaserMessageDelay: 5000,
-							text: "Hi there!",
-						},
-						startBehavior: {
-							getStartedText: "",
-						},
-						widgetSettings: {
-							enableFocusTrap: true,
-						},
-					},
-				},
-			).then(function (webchat) {
-				window.cognigyWebchat = webchat;
-				// webchat.open();
-				// webchat.startConversation();
-				window.cognigyWebchat.registerAnalyticsService(event => {
-					if (event.type === "webchat/close") {
-						webchat.endSession();
-					}
-				});
-			});
-		</script>
-	</body>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>webchat development</title>
+</head>
+
+<body>
+    <script src="./webchat.js"></script>
+    <script>
+            initWebchat('https://endpoint-dev.cognigy.ai/896f0112910ff0755a529b4dcb1622aeaf9931e516b52e8528603ad10d879661', {
+            // userId: "user1",
+            // sessionId: "session1",
+            settings: {
+                layout: {
+                    watermark: "default",
+                    watermarkText: "Some Random Watermark"
+                },
+                unreadMessages: {
+                    enableIndicator: true,
+                    enableBadge: true,  
+                    enablePreview: true,
+                    enableSound: true
+                },
+                teaserMessage:{
+                    showInChat: true,
+                    teaserMessageDelay: 5000,
+                    text: "Hi there!"
+                    },
+                startBehavior: {
+                    getStartedText: ""
+                },
+                widgetSettings: {
+                    enableFocusTrap: true,
+                }
+            },
+        }).then(function (webchat) {
+            window.cognigyWebchat = webchat;
+            // webchat.open();
+			// webchat.startConversation();
+        })
+    </script>
+</body>
+
 </html>

--- a/docs/analytics-api.md
+++ b/docs/analytics-api.md
@@ -23,16 +23,27 @@ Anytime an event is being emitted within the Webchat, it will cause the passed c
 The `event` object will always have a `type` property and may have a `payload` property depending on the event.
 By checking for `event.type`, you can filter events for the ones you are interested in.
 
+If you e.g. want to end session when user closes the webchat widget, you can do it like this:
+```javascript
+webchat.registerAnalyticsService(event => {
+	if (event.type === "webchat/close") {
+		webchat.endSession()
+	}
+})
+``` 
+This will end the current session and clear any messages from the session.
+
 ## Webchat Events
 
-| Type                       | Payload          | Description                                                  |
-| -------------------------- | ---------------- | ------------------------------------------------------------ |
-| `webchat/open`             | -                | The webchat was opened                                       |
-| `webchat/close`            | -                | The webchat was closed                                       |
-| `webchat/minimize`         | -                | The webchat was minimized                                    |
-| `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy                          |
-| `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy                                |
-| `plugin/messenger/action`  | `Object`         | An action was triggered from a Webchat or Messenger Template |
+| Type                     | Payload     | Description               |
+| ------------------------ | ----------- | ------------------------- |
+| `webchat/open`           | -           | The webchat was opened    |
+| `webchat/close`          | -           | The webchat was closed    |
+| `webchat/minimize`       | -           | The webchat was minimized |
+| `webchat/switch-session` | `sessionId` | The session was switched  |
+| `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy |
+| `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy |
+| `plugin/messenger/action` | `Object` | An action was triggered from a Webchat or Messenger Template |
 
 See it in action:  
 [![Edit Analytics API](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/using-the-webchat-api-ho5nk?fontsize=14&hidenavigation=1&theme=dark)

--- a/docs/analytics-api.md
+++ b/docs/analytics-api.md
@@ -24,26 +24,28 @@ The `event` object will always have a `type` property and may have a `payload` p
 By checking for `event.type`, you can filter events for the ones you are interested in.
 
 If you e.g. want to end session when user closes the webchat widget, you can do it like this:
+
 ```javascript
 webchat.registerAnalyticsService(event => {
 	if (event.type === "webchat/close") {
-		webchat.endSession()
+		webchat.endSession();
 	}
-})
-``` 
+});
+```
+
 This will end the current session and clear any messages from the session.
 
 ## Webchat Events
 
-| Type                     | Payload     | Description               |
-| ------------------------ | ----------- | ------------------------- |
-| `webchat/open`           | -           | The webchat was opened    |
-| `webchat/close`          | -           | The webchat was closed    |
-| `webchat/minimize`       | -           | The webchat was minimized |
-| `webchat/switch-session` | `sessionId` | The session was switched  |
-| `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy |
-| `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy |
-| `plugin/messenger/action` | `Object` | An action was triggered from a Webchat or Messenger Template |
+| Type                       | Payload          | Description                                                  |
+| -------------------------- | ---------------- | ------------------------------------------------------------ |
+| `webchat/open`             | -                | The webchat was opened                                       |
+| `webchat/close`            | -                | The webchat was closed                                       |
+| `webchat/minimize`         | -                | The webchat was minimized                                    |
+| `webchat/switch-session`   | `sessionId`      | The session was switched                                     |
+| `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy                          |
+| `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy                                |
+| `plugin/messenger/action`  | `Object`         | An action was triggered from a Webchat or Messenger Template |
 
 See it in action:  
 [![Edit Analytics API](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/using-the-webchat-api-ho5nk?fontsize=14&hidenavigation=1&theme=dark)

--- a/docs/analytics-api.md
+++ b/docs/analytics-api.md
@@ -29,6 +29,7 @@ By checking for `event.type`, you can filter events for the ones you are interes
 | -------------------------- | ---------------- | ------------------------------------------------------------ |
 | `webchat/open`             | -                | The webchat was opened                                       |
 | `webchat/close`            | -                | The webchat was closed                                       |
+| `webchat/minimize`         | -                | The webchat was minimized                                    |
 | `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy                          |
 | `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy                                |
 | `plugin/messenger/action`  | `Object`         | An action was triggered from a Webchat or Messenger Template |

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -92,7 +92,7 @@ export interface WebchatUIProps {
 	inputMode: string;
 	onSetInputMode: (inputMode: string) => void;
 	onClose: () => void;
-	onConnect: () => void;
+	onMinimize: () => void;
 	onToggle: () => void;
 	lastInputId: string;
 
@@ -1218,8 +1218,9 @@ export class WebchatUI extends React.PureComponent<
 		// TODO: implement better navigation history and currentPage string property on redux
 		const isSecondaryView = showInformationMessage;
 
-		const handleOnClose = () => {
-			onClose?.();
+		/** Minimize will only change the open state of the webchat */
+		const handleOnMinimize = () => {
+			this.props.onMinimize?.();
 			// Restore focus to chat toggle button
 			this.chatToggleButtonRef?.current?.focus?.();
 		};
@@ -1414,7 +1415,7 @@ export class WebchatUI extends React.PureComponent<
 						{!isXAppOverlayOpen && (
 							<Header
 								onClose={handleCloseAndReset}
-								onMinimize={handleOnClose}
+								onMinimize={handleOnMinimize}
 								onGoBack={showInformationMessage ? undefined : handleOnGoBack}
 								onSetShowChatOptionsScreen={() => {
 									onSetShowChatOptionsScreen(true);
@@ -1455,7 +1456,7 @@ export class WebchatUI extends React.PureComponent<
 							onSetShowHomeScreen={onSetShowHomeScreen}
 							onStartConversation={this.handleStartConversation}
 							onSetShowPrevConversations={onSetShowPrevConversations}
-							onClose={handleOnClose}
+							onClose={handleOnMinimize}
 							config={config}
 							onEmitAnalytics={onEmitAnalytics}
 							onSendActionButtonMessage={this.handleSendActionButtonMessage}

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -14,6 +14,7 @@ import {
 	setHasAcceptedTerms,
 	UIState,
 	setStoredMessage,
+	setMinimize,
 } from "../store/ui/ui-reducer";
 import { getPluginsForMessage, isFullscreenPlugin } from "../../plugins/helper";
 import { connect as doConnect } from "../store/connection/connection-middleware";
@@ -139,6 +140,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
 		onSetFullscreenMessage: message => dispatch(setFullscreenMessage(message)),
 		onDismissFullscreenMessage: () => dispatch(setFullscreenMessage(undefined)),
 		onClose: () => dispatch(setOpen(false)),
+		onMinimize: () => dispatch(setMinimize()),
 		onToggle: () => dispatch(toggleOpen()),
 		onTriggerEngagementMessage: () => dispatch(triggerEngagementMessage()),
 		onConnect: () => dispatch(doConnect()),

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -42,7 +42,6 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 	public client: SocketClient;
 	public analytics: EventEmitter = new EventEmitter();
 	public _handleOutput: (output: unknown) => void;
-	protected storage: ReturnType<typeof getStorage>;
 	// component lifecycle methods
 	constructor(props: WebchatProps) {
 		super(props);
@@ -62,10 +61,6 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 		this.store = store;
 
 		this._handleOutput = createOutputHandler(this.store);
-		this.storage = getStorage({
-			disableLocalStorage: settings?.embeddingConfiguration?.disableLocalStorage ?? false,
-			useSessionStorage: settings?.embeddingConfiguration?.useSessionStorage ?? false,
-		});
 	}
 
 	UNSAFE_componentWillMount() {
@@ -192,6 +187,9 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 		this.store.dispatch(updateSettings(settings));
 	};
 
+	/**
+	 * This method will switch to a new session and clear the messages in the current session.
+	 */
 	endSession = () => {
 		this.store.dispatch(switchSession());
 		this.store.dispatch(clearMessages());

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -27,6 +27,8 @@ import { createNotification } from "../../webchat-ui/components/presentational/N
 import { getStorage } from "../helper/storage";
 import { hasAcceptedTermsInStorage } from "../helper/privacyPolicy";
 import { setUserId } from "../store/options/options-reducer";
+import { switchSession } from "../store/previous-conversations/previous-conversations-middleware";
+import { clearMessages } from "../store/messages/message-reducer";
 
 export interface WebchatProps extends FromProps {
 	url: string;
@@ -40,7 +42,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 	public client: SocketClient;
 	public analytics: EventEmitter = new EventEmitter();
 	public _handleOutput: (output: unknown) => void;
-
+	protected storage: ReturnType<typeof getStorage>;
 	// component lifecycle methods
 	constructor(props: WebchatProps) {
 		super(props);
@@ -60,6 +62,10 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 		this.store = store;
 
 		this._handleOutput = createOutputHandler(this.store);
+		this.storage = getStorage({
+			disableLocalStorage: settings?.embeddingConfiguration?.disableLocalStorage ?? false,
+			useSessionStorage: settings?.embeddingConfiguration?.useSessionStorage ?? false,
+		});
 	}
 
 	UNSAFE_componentWillMount() {
@@ -184,6 +190,11 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 
 	updateSettings = (settings: IWebchatSettings) => {
 		this.store.dispatch(updateSettings(settings));
+	};
+
+	endSession = () => {
+		this.store.dispatch(switchSession());
+		this.store.dispatch(clearMessages());
 	};
 
 	render() {

--- a/src/webchat/store/analytics/analytics-middleware.ts
+++ b/src/webchat/store/analytics/analytics-middleware.ts
@@ -1,6 +1,6 @@
 import { Middleware } from "redux";
 import { StoreState } from "../store";
-import { SetOpenAction, ToggleOpenAction } from "../ui/ui-reducer";
+import { SetOpenAction, ToggleOpenAction, SetMinimizeAction } from "../ui/ui-reducer";
 import { SendMessageAction } from "../messages/message-middleware";
 import { ReceiveMessageAction } from "../messages/message-handler";
 import { Webchat } from "../../components/Webchat";
@@ -8,6 +8,7 @@ import { SwitchSessionAction } from "../previous-conversations/previous-conversa
 
 type AnalyticsAction =
 	| SetOpenAction
+	| SetMinimizeAction
 	| ToggleOpenAction
 	| SendMessageAction
 	| ReceiveMessageAction
@@ -22,6 +23,11 @@ export const createAnalyticsMiddleware =
 		switch (action.type) {
 			case "SET_OPEN": {
 				webchat.emitAnalytics(action.open ? "webchat/open" : "webchat/close");
+				break;
+			}
+
+			case "SET_MINIMIZE": {
+				webchat.emitAnalytics("webchat/minimize");
 				break;
 			}
 

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -32,6 +32,12 @@ export const setOpen = (open: boolean) => ({
 });
 export type SetOpenAction = ReturnType<typeof setOpen>;
 
+export const SET_MINIMIZE = "SET_MINIMIZE" as const;
+export const setMinimize = () => ({
+	type: SET_MINIMIZE,
+});
+export type SetMinimizeAction = ReturnType<typeof setMinimize>;
+
 const TOGGLE_OPEN = "TOGGLE_OPEN";
 export const toggleOpen = () => ({
 	type: TOGGLE_OPEN as "TOGGLE_OPEN",
@@ -154,6 +160,7 @@ const getInitialState = (): UIState => ({
 
 type UIAction =
 	| SetOpenAction
+	| SetMinimizeAction
 	| SetTypingAction
 	| SetInputModeAction
 	| SetFullscreenMessageAction
@@ -174,6 +181,13 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
 			return {
 				...state,
 				open: action.open,
+			};
+		}
+
+		case SET_MINIMIZE: {
+			return {
+				...state,
+				open: false,
 			};
 		}
 


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- Closing the webchat using close button should reset the session 
- This happens only while in the chat screen
- Also live agents should notified correctly i.e User left conversation


# How to test

Please describe the individual steps on how a peer can test your change.

1. Open a webchat
2. Chat with the bot
3. Click close
4. Open the webchat again 
5. Observe the home screen appears when home screen is enabled
6. If home screen is disabled , the a new conversation session is opened
7. Test live agents by observing user left conversation 

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
