### PR TITLE
fix: #80613 refactor getTextFromMessage to improve text extraction and HTML stripping

### DIFF
--- a/src/webchat/helper/message.ts
+++ b/src/webchat/helper/message.ts
@@ -4,20 +4,27 @@ import { IMessage } from "../../common/interfaces/message";
 
 const getTextFromMessage = (message: IMessage) => {
 	// Check if message is plain text
+	let text: string | string[] = "";
 	if (message?.text) {
-		return message.text;
+		text = message.text;
 		// Check if message is quick reply message
 	} else if (message?.data?._cognigy?._webchat?.message?.text) {
-		return message.data._cognigy._webchat.message.text;
+		text = message.data._cognigy._webchat.message.text;
 		// Check if message is button message
 	} else if (
 		message?.data?._cognigy?._webchat?.message?.attachment?.type === "template" &&
 		message?.data?._cognigy?._webchat?.message?.attachment?.payload?.template_type === "button"
 	) {
-		return message.data._cognigy._webchat.message.attachment.payload.text;
-	} else {
-		return "";
+		text = message.data._cognigy._webchat.message.attachment.payload.text;
 	}
+	// Before return the text strip HTML tags
+	if (Array.isArray(text)) {
+		text = text.map(t => t.replace(/(<([^>]+)>)/gi, ""));
+	}
+	if (typeof text === "string") {
+		text = text.replace(/(<([^>]+)>)/gi, "");
+	}
+	return text;
 };
 
 export const getMessageAttachmentType = (message: IMessage): string => {


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- Messages snippets in teaser and previous conversation list should be not contain html markup
- Only Messages inside chat box should contain html markup if any
- Should applicable for all types of text messages

# How to test

Please describe the individual steps on how a peer can test your change.

1. Create a flow with a say node containing html embedded text
2. Deploy a webchat endpoint and test it the endpoint 
3. Start chatting with the bot 
4. Minimize the tab
5. Observe the teaser message in message preview is without any html
6. Also in the previous conversation list

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
