### PR TITLE
Feature/100891 text sizing a11y

### DIFF
--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -172,7 +172,7 @@ The following code snippets are just suggestions so it shows the syntax required
 ```CSS
 [data-cognigy-webchat-root] [data-cognigy-webchat].webchat .webchat-header-title {
 
-    font-size: 20px;
+    font-size: 1.25rem;
 }
 ```
 
@@ -500,7 +500,7 @@ The avatars can be repositioned to appear at the top edge of a message rather th
 ```CSS
 [data-cognigy-webchat-root] .webchat-unread-message-preview-text {
     color: white;
-    font-size: 14px;
+    font-size: 0.875rem;
 }
 ```
 
@@ -519,7 +519,7 @@ The avatars can be repositioned to appear at the top edge of a message rather th
 
 ```CSS
 [data-cognigy-webchat-root] .webchat-teaser-message-header-title {
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: bold;
     color: rgb(5, 5, 131);
 }
@@ -811,7 +811,7 @@ To change the font-family of the homescreen starter button labels, you need to t
 
 ```CSS
 [data-cognigy-webchat-root] .webchat-chat-options-action-btns-title {
-    font-size: 18px;
+    font-size: 1.125rem;
     font-family: Arial, Helvetica, sans-serif;
     color: rgb(5, 5, 131);
 }
@@ -841,7 +841,7 @@ To change the font-family of the homescreen starter button labels, you need to t
 
 ```CSS
 [data-cognigy-webchat-root] .webchat-rating-widget-title {
-    font-size: 20px;
+    font-size: 1.25rem;
     color: rgb(5, 5, 131);
 }
 ```
@@ -888,7 +888,7 @@ To change the font-family of the homescreen starter button labels, you need to t
 
 ```CSS
 [data-cognigy-webchat-root] .webchat-rating-widget-comment-input-field-label {
-    font-size: 20px;
+    font-size: 1.25rem;
 }
 ```
 
@@ -925,7 +925,7 @@ To change the font-family of the homescreen starter button labels, you need to t
 
 ```CSS
 [data-cognigy-webchat-root] .webchat-chat-options-footer-link-text {
-    font-size: 14px;
+    font-size: 0.875rem;
     font-family: Arial, Helvetica, sans-serif !important;
 }
 ```
@@ -1305,7 +1305,7 @@ The frame that adds the "card styles" such as background-color or box-shadow.
   background: #28c8ef;
   color: hsla(0, 0%, 100%, 0.95);
   font-weight: bold;
-  font-size: 22px;
+  font-size: 1.375rem;
 }
 ```
 
@@ -1385,7 +1385,7 @@ The frame that adds the "card styles" such as background-color or box-shadow.
 
 ```CSS
 [data-cognigy-webchat-root] .webchat-modal-title {
-    font-size: 18px;
+    font-size: 1.125rem;
     color: #333;
     font-weight: bold;
 }
@@ -1466,7 +1466,7 @@ The frame that adds the "card styles" such as background-color or box-shadow.
 
 ```CSS
 [data-cognigy-webchat-root] .webchat-delete-conversation-title {
-    font-size: 16px;
+    font-size: 1rem;
     font-weight: bold;
     color: #333;
 }

--- a/src/webchat-ui/components/branding/Branding.tsx
+++ b/src/webchat-ui/components/branding/Branding.tsx
@@ -49,7 +49,7 @@ const Branding: FC<IBrandingProps> = props => {
 			aria-label={`${watermarkText}. ${ariaLabels?.opensInNewTab ?? "Opens in new tab"}`}
 			id={id ?? "cognigyBrandingLink"}
 		>
-			<Typography variant="copy-medium" component="span" fontSize={10} lineHeight="120%">
+			<Typography variant="copy-medium" component="span" fontSize="0.625rem" lineHeight="120%">
 				{watermark === "custom" && watermarkText ? watermarkText : "Powered by Cognigy.AI"}
 			</Typography>
 		</Link>

--- a/src/webchat-ui/components/branding/Branding.tsx
+++ b/src/webchat-ui/components/branding/Branding.tsx
@@ -49,7 +49,12 @@ const Branding: FC<IBrandingProps> = props => {
 			aria-label={`${watermarkText}. ${ariaLabels?.opensInNewTab ?? "Opens in new tab"}`}
 			id={id ?? "cognigyBrandingLink"}
 		>
-			<Typography variant="copy-medium" component="span" fontSize="0.625rem" lineHeight="120%">
+			<Typography
+				variant="copy-medium"
+				component="span"
+				fontSize="0.625rem"
+				lineHeight="120%"
+			>
 				{watermark === "custom" && watermarkText ? watermarkText : "Powered by Cognigy.AI"}
 			</Typography>
 		</Link>

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -40,7 +40,7 @@ const TextArea = styled(TextareaAutosize)(({ theme }) => ({
 	resize: "none",
 	backgroundColor: "transparent",
 
-	fontSize: 14,
+	fontSize: "0.875rem", // 14px
 	fontStyle: "normal",
 	fontWeight: 400,
 	lineHeight: "140%",

--- a/src/webchat-ui/components/plugins/input/base/FloatingLabel.tsx
+++ b/src/webchat-ui/components/plugins/input/base/FloatingLabel.tsx
@@ -15,7 +15,7 @@ const Label = styled.label<{ visible: boolean; disabled?: boolean }>(
 		left: 0,
 		top: 0,
 		color: disabled ? theme.black50 : theme.black10,
-		fontSize: 14,
+		fontSize: "0.875rem", // 14px
 		fontWeight: 400,
 		lineHeight: "140%",
 		pointerEvents: "none",

--- a/src/webchat-ui/components/presentational/Button.tsx
+++ b/src/webchat-ui/components/presentational/Button.tsx
@@ -24,7 +24,7 @@ export default styled.button<IColorProps>(({ color, theme }) => {
 		display: "flex",
 		width: "19rem", // 303px
 		height: "2.75rem", // 44px
-		padding: "0.8rem 0", // 11px top/bottom
+		padding: "11px 0",
 		justifyContent: "center",
 		alignItems: "center",
 		flexShrink: 0,

--- a/src/webchat-ui/components/presentational/Button.tsx
+++ b/src/webchat-ui/components/presentational/Button.tsx
@@ -22,9 +22,9 @@ export default styled.button<IColorProps>(({ color, theme }) => {
 
 		borderRadius: 10,
 		display: "flex",
-		width: 303,
-		height: 44,
-		padding: "11px 0px",
+		width: "19rem", // 303px
+		height: "2.75rem", // 44px
+		padding: "0.8rem 0", // 11px top/bottom
 		justifyContent: "center",
 		alignItems: "center",
 		flexShrink: 0,
@@ -33,7 +33,7 @@ export default styled.button<IColorProps>(({ color, theme }) => {
 		color: colors.contrast,
 
 		textTransform: "unset",
-		fontSize: 14,
+		fontSize: "0.875rem", // 14px
 		fontStyle: "normal",
 		fontWeight: 600,
 		lineHeight: "160%",

--- a/src/webchat-ui/components/presentational/MultilineInput.tsx
+++ b/src/webchat-ui/components/presentational/MultilineInput.tsx
@@ -8,7 +8,6 @@ const InputWrapper = styled.div<{ disabled?: boolean }>(({ theme, disabled }) =>
 	border: `1px solid var(--basics-black-60, ${theme.black60})`,
 	background: `var(--Basics-white, ${theme.white})`,
 	width: "100%",
-	height: "100px",
 	padding: 12,
 	"&:focus-within": {
 		borderColor: "transparent",

--- a/src/webchat-ui/components/presentational/MultilineInput.tsx
+++ b/src/webchat-ui/components/presentational/MultilineInput.tsx
@@ -26,7 +26,7 @@ const Input = styled.textarea(({ theme }) => ({
 
 	color: theme.black10,
 	fontFamily: "Figtree",
-	fontSize: 14,
+	fontSize: "0.875rem", // 14px
 	fontWeight: 400,
 	lineHeight: "140%",
 

--- a/src/webchat-ui/components/presentational/chat-options/RatingWidget.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/RatingWidget.tsx
@@ -12,7 +12,6 @@ import { useSelector } from "../../../../webchat/helper/useSelector";
 
 const RatingWidgetRoot = styled.div({
 	width: "100%",
-	height: "310px",
 	display: "flex",
 	flexDirection: "column",
 	padding: "20px 0",

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsListItem.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsListItem.tsx
@@ -12,7 +12,7 @@ import { IMessage } from "../../../../common/interfaces/message";
 const ListItem = styled.div(({ theme }) => ({
 	display: "flex",
 	gap: "12px",
-	height: "69px",
+	height: "4.32rem", // ~69px
 	width: "100%",
 	border: `1px solid ${theme.black80}`,
 	borderRadius: "10px",


### PR DESCRIPTION
This PR updates all font sizes from px to rem units for accessibility(text-only zoom), ensuring that UI components scale properly when browser text size is increased up to 32px (200% of the default 16px), in accordance with WCAG 2.1 Level AA requirements.

# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- Font sizes previously set in px are now set in rem units for accessibility.
- UI components scale properly when browser text size is increased (text-only zoom).
- No visual overlap or layout breakage occurs when font size is increased.
- All interactive elements remain accessible and usable at larger font sizes.

# How to test

Please describe the individual steps on how a peer can test your change.

Test this together with https://github.com/Cognigy/chat-components/pull/139

1. Open the webchat UI in a browser.
2. Increase the browser's font size (e.g., set font size to 32px). In Chrome you can do this under Settings > Appearance > Customize fonts > Font size
3. Verify that all buttons, inputs, labels, and various message types scale appropriately and do not overlap. Check all the screens: Home screen, chat options etc. Do a comparison with demo-webchat
4. Check that all interactive elements remain accessible and visually clear.

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

In accessibility documentation: Customers customizing the webchat UI via class names should use relative font sizes (e.g., rem, em) instead of pixels (px) to ensure accessibility and proper scaling with user browser settings.