### PR TITLE
Data-Only Messages Are Not Counted as Replies

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1600,7 +1600,8 @@ export class WebchatUI extends React.PureComponent<
 							message =>
 								message.source === "user" &&
 								!(message?.data?._cognigy as any)?.controlCommands &&
-								!!message.text?.trim(),
+								!(message?.data?.attachments) &&
+								!!message?.text?.trim(),
 						);
 
 					return (

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1600,7 +1600,7 @@ export class WebchatUI extends React.PureComponent<
 							message =>
 								message.source === "user" &&
 								!(message?.data?._cognigy as any)?.controlCommands &&
-								!(message?.data?.attachments) &&
+								!message?.data?.attachments &&
 								!!message?.text?.trim(),
 						);
 

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1593,7 +1593,7 @@ export class WebchatUI extends React.PureComponent<
 					</TopStatusMessage>
 				)}
 				{visibleMessages.map((message, index) => {
-					// Lookahead if there is a user reply
+					// Lookahead if there is a user reply that includes text or attachments
 					const hasReply = visibleMessages.slice(index + 1).some(message => {
 						const isUser = message.source === "user";
 						const hasText = !!message?.text?.trim();

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1600,7 +1600,7 @@ export class WebchatUI extends React.PureComponent<
 							message =>
 								message.source === "user" &&
 								!(message?.data?._cognigy as any)?.controlCommands &&
-								!!message.text,
+								!!message.text?.trim(),
 						);
 
 					return (

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1599,7 +1599,9 @@ export class WebchatUI extends React.PureComponent<
 						const hasText = !!message?.text?.trim();
 						const noControlCommands = !(message?.data?._cognigy as any)
 							?.controlCommands;
-						const hasAttachments = Array.isArray(message?.data?.attachments) && message.data.attachments.length > 0;
+						const hasAttachments =
+							Array.isArray(message?.data?.attachments) &&
+							message.data.attachments.length > 0;
 
 						return isUser && noControlCommands && (hasText || hasAttachments);
 					});

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1599,7 +1599,7 @@ export class WebchatUI extends React.PureComponent<
 						const hasText = !!message?.text?.trim();
 						const noControlCommands = !(message?.data?._cognigy as any)
 							?.controlCommands;
-						const hasAttachments = !!message?.data?.attachments;
+						const hasAttachments = Array.isArray(message?.data?.attachments) && message.data.attachments.length > 0;
 
 						return isUser && noControlCommands && (hasText || hasAttachments);
 					});

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1594,15 +1594,15 @@ export class WebchatUI extends React.PureComponent<
 				)}
 				{visibleMessages.map((message, index) => {
 					// Lookahead if there is a user reply
-					const hasReply = visibleMessages
-						.slice(index + 1)
-						.some(
-							message =>
-								message.source === "user" &&
-								!(message?.data?._cognigy as any)?.controlCommands &&
-								!message?.data?.attachments &&
-								!!message?.text?.trim(),
-						);
+					const hasReply = visibleMessages.slice(index + 1).some(message => {
+						const isUser = message.source === "user";
+						const hasText = !!message?.text?.trim();
+						const noControlCommands = !(message?.data?._cognigy as any)
+							?.controlCommands;
+						const hasAttachments = !!message?.data?.attachments;
+
+						return isUser && noControlCommands && (hasText || hasAttachments);
+					});
 
 					return (
 						<Message

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1599,7 +1599,8 @@ export class WebchatUI extends React.PureComponent<
 						.some(
 							message =>
 								message.source === "user" &&
-								!(message?.data?._cognigy as any)?.controlCommands,
+								!(message?.data?._cognigy as any)?.controlCommands &&
+								!!message.text,
 						);
 
 					return (


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- This PR changes the logic of which user-message are accounted as a reply.
 
# How to test

Please describe the individual steps on how a peer can test your change.

1. Have a bot with some QRs.
2. Init Webchat with a static session. Talk to a bot, recieve QRs
3. Add some logic to send a message programmatically, e.g. use Webchat.sendMessage API with some delay. (data-only message  webchat.sendMessage("", { "test:: "test" });).
4. Open Webchat again.
5. Check session is restored. Check the hidden data message is sent. Check the QRs remain active.

- [ ] Possible injecti.on vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
