### PR TITLE
Handle message IDs correctly when output collation is disabled

### DIFF
--- a/src/webchat/store/messages/message-reducer.ts
+++ b/src/webchat/store/messages/message-reducer.ts
@@ -157,11 +157,12 @@ export const createMessageReducer = (getState: () => { config: ConfigState }) =>
 
 				const finishReason = getFinishReason(newMessage, newMessageId);
 
-				if (!newMessageId) {
+				// When collation is disabled each single chunk of message coming from endpoint is treated a separate message with its own message id
+				if (!newMessageId || !isOutputCollationEnabled) {
 					newMessageId = generateRandomId();
 				}
 
-				if (!nextAnimatingId) {
+				if (!nextAnimatingId && newMessageId) {
 					nextAnimatingId = newMessageId;
 				}
 
@@ -172,6 +173,7 @@ export const createMessageReducer = (getState: () => { config: ConfigState }) =>
 
 				// If no matching message, create new with array
 				if (messageIndex === -1) {
+
 					if (!state.currentlyAnimatingId) {
 						visibleOutputMessages.push(newMessageId as string);
 					}
@@ -180,7 +182,6 @@ export const createMessageReducer = (getState: () => { config: ConfigState }) =>
 					const textChunks = (newMessage.text as string)
 						.split(/(\n)/)
 						.filter(chunk => chunk.length > 0);
-
 					return {
 						...state,
 						messageHistory: [
@@ -190,11 +191,12 @@ export const createMessageReducer = (getState: () => { config: ConfigState }) =>
 								text: textChunks,
 								id: newMessageId,
 								animationState: "start",
-								finishReason,
+								// Finish reason stop means the message is generated and it will start rendering
+								finishReason : isOutputCollationEnabled ? finishReason : "stop",
 							},
 						],
 						visibleOutputMessages,
-						currentlyAnimatingId: nextAnimatingId,
+						currentlyAnimatingId: nextAnimatingId
 					};
 				}
 


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- When progressive rendering alone is enabled , 
- AI agent node should display all the messages correctly


# How to test

Please describe the individual steps on how a peer can test your change.

1. Create a flow a AI agent node
2. Create an endpoint with PR enabled
3. Chat with the bot
4. Observe the messages are progressively rendered without any animation break

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
