### PR TITLE
Enable User Typing Events

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -160,7 +160,7 @@ See it in action:
 | scrollingBehavior               | string  | `"alwaysScroll"`                      | Allowed values: `"scrollUntilLastInputAtTop" \| "alwaysScroll"`. Decide how scrolling should behave if scrolled to bottom and a new message comes in.                                               |
 | enableScrollButton              | boolean | `true`                                | If false, hides the scroll-to-bottom button.                                                                                                                                                        |
 
-| disableUserTypingEvent | boolean | `true` | If true, disables sending typing events from user.
+| disableUserTypingEvent | boolean | `false` | If true, disables sending typing events from user.
 
 #### Start Behavior
 

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -55,7 +55,7 @@ export const getInitialState = (): ConfigState => ({
 			focusInputAfterPostback: false,
 			enableConnectionStatusIndicator: true,
 			scrollingBehavior: "alwaysScroll",
-			disableUserTypingEvent: true,
+			disableUserTypingEvent: false,
 		},
 		startBehavior: {
 			startBehavior: "none",


### PR DESCRIPTION
# Success criteria

- User Typing events are enabled by default.
- With empty local config, the webchat sends user typing events.

# How to test

1. Connect to any endpoint.
2. Open Network Panel -> Socket.
3. Start typing a message in Webchat.
4. Check Socket Messages

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications