### PR TITLE
add parameter to override bot name

### DIFF
--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -1,7 +1,7 @@
 import { Store } from "redux";
 import { IMessage } from "../../../common/interfaces/message";
 import { ISendMessageOptions } from "./message-middleware";
-import { setBotAvatarOverrideUrl, setAgentAvatarOverrideUrl, setTyping } from "../ui/ui-reducer";
+import { setBotAvatarNameOverride, setBotAvatarOverrideUrl, setAgentAvatarOverrideUrl, setTyping } from "../ui/ui-reducer";
 import {
 	setCustomRatingCommentText,
 	setCustomRatingTitle,
@@ -34,7 +34,7 @@ export type ReceiveEventAction = ReturnType<typeof receiveEvent>;
 export const createOutputHandler = (store: Store) => output => {
 	// handle custom webchat actions
 	if (output.data && output.data._webchat) {
-		const { agentAvatarOverrideUrl, botAvatarOverrideUrl } = output.data._webchat;
+		const { agentAvatarOverrideUrl, botAvatarOverrideUrl, botAvatarNameOverride } = output.data._webchat;
 
 		if (agentAvatarOverrideUrl !== undefined) {
 			store.dispatch(setAgentAvatarOverrideUrl(agentAvatarOverrideUrl));
@@ -42,6 +42,10 @@ export const createOutputHandler = (store: Store) => output => {
 
 		if (botAvatarOverrideUrl !== undefined) {
 			store.dispatch(setBotAvatarOverrideUrl(botAvatarOverrideUrl));
+		}
+
+		if (botAvatarNameOverride !== undefined) {
+			store.dispatch(setBotAvatarNameOverride(botAvatarNameOverride));
 		}
 	}
 

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -83,6 +83,7 @@ export const getAvatarNameForMessage = (message: IMessage, state: StoreState) =>
 		case "bot":
 		case "engagement":
 			return (
+				state.ui.botAvatarNameOverride ||
 				(state.config.settings.layout.useOtherAgentLogo &&
 					state.config.settings.layout.botAvatarName) ||
 				state.config.settings.layout.title ||

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -11,6 +11,7 @@ export interface UIState {
 	fullscreenMessage: IMessage | undefined;
 	agentAvatarOverrideUrl?: string;
 	botAvatarOverrideUrl?: string;
+	botAvatarNameOverride?: string;
 	isPageVisible: boolean;
 	showHomeScreen: boolean;
 	showPrevConversations: boolean;
@@ -106,6 +107,13 @@ export const setBotAvatarOverrideUrl = (url: string) => ({
 });
 type SetBotAvatarOverrideUrlAction = ReturnType<typeof setBotAvatarOverrideUrl>;
 
+const SET_BOT_AVATAR_NAME_OVERRIDE = "SET_BOT_AVATAR_NAME_OVERRIDE";
+export const setBotAvatarNameOverride = (name: string) => ({
+	type: SET_BOT_AVATAR_NAME_OVERRIDE as "SET_BOT_AVATAR_NAME_OVERRIDE",
+	name,
+});
+type SetBotAvatarNameOverrideAction = ReturnType<typeof setBotAvatarNameOverride>;
+
 const SET_PAGE_VISIBLE = "SET_PAGE_VISIBLE";
 export const setPageVisible = (visible: boolean) => ({
 	type: SET_PAGE_VISIBLE as "SET_PAGE_VISIBLE",
@@ -166,6 +174,7 @@ type UIAction =
 	| SetFullscreenMessageAction
 	| SetAgentAvatarOverrideUrlAction
 	| SetBotAvatarOverrideUrlAction
+	| SetBotAvatarNameOverrideAction
 	| SetPageVisibleAction
 	| SetShowHomeScreenAction
 	| SetShowPrevConversationsAction
@@ -244,6 +253,13 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
 			return {
 				...state,
 				botAvatarOverrideUrl: action.url,
+			};
+		}
+
+		case SET_BOT_AVATAR_NAME_OVERRIDE: {
+			return {
+				...state,
+				botAvatarNameOverride: action.name,
 			};
 		}
 


### PR DESCRIPTION
# Success criteria

- Overriding bot name during chat using `botAvatarNameOverride` like this:
```js
{
  "_webchat": {
    "botAvatarNameOverride": "Bob"
  }
}
```
<img width="1022" height="999" alt="Screenshot 2025-07-17 at 00 54 42" src="https://github.com/user-attachments/assets/d65c1a6b-003d-41bd-8d56-49a44474527c" />

# How to test

Create a flow on Cognigy. Add a Say node and specify in the options the above example config. Then test the endpoint and see the bot name being overridden.

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications


