### PR TITLE
Fix screen-reader announcement for streaming messages

### DIFF
--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -48,10 +48,7 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 					firstUnannouncedMsg.animationState === "animating");
 
 			// If streaming, don't announce yet
-			if (isStreaming) {
-				clearTimeout(timeout);
-				return;
-			}
+			if (isStreaming) return;
 
 			announcedIdsRef.current.add(id);
 

--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -28,13 +28,17 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 
 		if (!unannouncedMessages.length) return;
 
+		const hasAnimationState = (msg: any): msg is { animationState: string } => {
+			return msg && typeof msg.animationState === "string";
+		};
+
 		const timeout = setTimeout(() => {
 			const firstUnannouncedMsg = unannouncedMessages[0]; // Only announce one at a time
 			const id = `webchatMessageId-${firstUnannouncedMsg.timestamp}`;
 
 			// Check if this is a streaming message that hasn't finished
 			const isStreamingMessage =
-				"animationState" in firstUnannouncedMsg &&
+				hasAnimationState(firstUnannouncedMsg) &&
 				(firstUnannouncedMsg.animationState === "start" ||
 					firstUnannouncedMsg.animationState === "animating");
 
@@ -53,6 +57,7 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 			const rawText = liveContent[id] || getTextFromDOM(id);
 			const text = cleanUpText(rawText || "A new message");
 
+			console.log(`Announcing message: ${text} (ID: ${id})`);
 			setLiveMessage({ id, text });
 		}, 100);
 

--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -31,6 +31,16 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 		const timeout = setTimeout(() => {
 			const firstUnannouncedMsg = unannouncedMessages[0]; // Only announce one at a time
 			const id = `webchatMessageId-${firstUnannouncedMsg.timestamp}`;
+
+			// Check if this is a streaming message that hasn't finished
+			const isStreamingMessage =
+				"animationState" in firstUnannouncedMsg &&
+				(firstUnannouncedMsg.animationState === "start" ||
+					firstUnannouncedMsg.animationState === "animating");
+
+			// If streaming, don't announce yet
+			if (isStreamingMessage) return;
+
 			announcedIdsRef.current.add(id);
 
 			// Skip announcement if the message is marked as "IGNORE". Done by ChatEvent message component, as it has aria-live="assertive"

--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -17,6 +17,7 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 	const messageHistory = useSelector(state => state.messages.messageHistory);
 	const messages = getMessagesListWithoutControlCommands(messageHistory, ["acceptPrivacyPolicy"]);
 	const announcedIdsRef = useRef<Set<string>>(new Set());
+	const isProgressiveRenderingEnabled = useSelector(state => state.config.settings.behavior?.progressiveMessageRendering);
 
 	useEffect(() => {
 		if (!messages.length) return;
@@ -43,7 +44,7 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 					firstUnannouncedMsg.animationState === "animating");
 
 			// If streaming, don't announce yet
-			if (isStreamingMessage) return;
+			if (isStreamingMessage && isProgressiveRenderingEnabled) return;
 
 			announcedIdsRef.current.add(id);
 
@@ -57,7 +58,6 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 			const rawText = liveContent[id] || getTextFromDOM(id);
 			const text = cleanUpText(rawText || "A new message");
 
-			console.log(`Announcing message: ${text} (ID: ${id})`);
 			setLiveMessage({ id, text });
 		}, 100);
 

--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -17,7 +17,9 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 	const messageHistory = useSelector(state => state.messages.messageHistory);
 	const messages = getMessagesListWithoutControlCommands(messageHistory, ["acceptPrivacyPolicy"]);
 	const announcedIdsRef = useRef<Set<string>>(new Set());
-	const isProgressiveRenderingEnabled = useSelector(state => state.config.settings.behavior?.progressiveMessageRendering);
+	const isProgressiveRenderingEnabled = useSelector(
+		state => state.config.settings.behavior?.progressiveMessageRendering,
+	);
 
 	useEffect(() => {
 		if (!messages.length) return;

--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -64,7 +64,7 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 		}, 100);
 
 		return () => clearTimeout(timeout);
-	}, [messages, liveContent]);
+	}, [messages, liveContent, isProgressiveRenderingEnabled]);
 
 	return (
 		<div


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- When progressive rendering is enabled, the messages are announced by the screen reader completely without being skipped
- Announcement of messages is not affected when progressive rendering is disabled

# How to test

Please describe the individual steps on how a peer can test your change.

Test it together with the chat-components PR that fixes the streaming of Quick-replies & text-with-buttons: https://github.com/Cognigy/chat-components/pull/161
1. Create a flow with different output types
2. Enable progressive rendering in endpoint setings
3. Talk to the bot with a screen reader enabled
4. See if all the messages are announced completely
5. See if no message is skipped
6. See if no message is announced twice
7. Also test the announcement of messages with progressive rendering disabed
# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
