### PR TITLE
Remove Full Lodash From Build

### DIFF
--- a/src/webchat-ui/components/plugins/input/base/ConnectedBaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/ConnectedBaseInput.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../../webchat/store/input/input-reducer";
 import { addFilesToList } from "../../../../../webchat/store/input/file-input-middleware";
 import { inputContentUpdated } from "../../../../../webchat/store/typing/actions";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 
 export const ConnectedBaseInput = (props: InputComponentProps) => {
 	const sttActive = useSelector((state: StoreState) => state.input.sttActive);


### PR DESCRIPTION
This PR is an attempt to fix a crash inside an Android Application Webview reported by one of the customers. As we do not have a mean to reproduce it, here we make our best effort on fixing it.

The issue araised at the time v3.24 was marked as latest. Also the logs provided by the customer point to an unhandeld exception. The error line number pointed to the lodash library in the build. 

Apparently, [this change](https://github.com/Cognigy/Webchat/pull/118/files#diff-2d3b5f6c35c337d24ad8e0741e15506786b18a9c4eb2206910848fffac489efaR15) led to the inclusion of the full library in build (the code optimizations did not happen in this case for an uninvestigated reason).

The proposed solution is to use other import path. We will ask the customer after the release for testing / confirmation.

# Success criteria

- Build does not include full lodash library.

# How to test

1. `npm run build`
2. Search for lodash in `dist/webchat.js`.
3. There should be no library license banner (which indicates the inclusion of its full version).

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications