### PR TITLE
#106458- Disable HTML in user messages by default

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -373,7 +373,7 @@ _These settings are NOT configurable via the Endpoint Editor in Cognigy.AI_
 | ----------------------------------- | ------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | disableDefaultReplyCompatiblityMode | boolean | `false` | If set to true, the webchat will not try to look for messenger content in data.\_data.\_cognigy. This can lead to issues with structured content in Intent Default Replies. |
 | enableStrictMessengerSync | boolean | `false` | If set to true, will NOT render the message from the "Messenger" tab in the SAY node unless "Use Facebook Channel" is checked in the "Webchat" tab. |
-| disableHtmlInput | boolean | `false` | If true, strips all html tags out from the input of the user. |
+| disableHtmlInput | boolean | `true` | If true, strips all html tags out from the input of the user. |
 | disableInputAutofocus | boolean | `false` | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget. |
 | disableRenderURLsAsLinks | boolean | `false` | If true, disables the automatic replacement of URLs in message elements with clickable HTML link elements. |
 | disableTextInputSanitization | boolean | `false` | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc. |

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -181,7 +181,7 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 			disableDefaultReplyCompatiblityMode: false,
 			enableStrictMessengerSync: false,
 
-			disableHtmlInput: false,
+			disableHtmlInput: true,
 			disableInputAutofocus: false,
 			disableRenderURLsAsLinks: false,
 			disableTextInputSanitization: false,


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- By default (disableHtmlInput is true), all HTML tags are stripped from the user messages 
- If disableHtmlInput is set to false, then user text message is sanitized based on the customAllowedHtmlTags - provided disableTextInputSanitization is false (default value)
- If disableHtmlInput is false and disableTextInputSanitization is true, then user text is not sanitized at all - even when customAllowedHtmlTags are provided.
- If both disableHtmlInput and disableTextInputSanitization set to true, then all HTML tags are stripped

# How to test

Please describe the individual steps on how a peer can test your change.

- Test this together with https://github.com/Cognigy/chat-components/pull/165
- Play around with the combination of disableHtmlInput, disableTextInputSanitization and customAllowedHtmlTags and see if the user text is sanitized as expected

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

**Security risk** - If disableHtmlInput is set to false and disableTextInputSanitization is true, as the user text will not be sanitized at all, allowing all HTML tags
