### PR TITLE
100891 - Replace px with rem in input field

### DIFF
--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -588,7 +588,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 													spellCheck={false}
 													id="webchatInputMessageInputInTextMode"
 													style={
-														matches ? { fontSize: "16px" } : undefined
+														matches ? { fontSize: "1rem" } : undefined
 													}
 												/>
 											</InputContainer>

--- a/src/webchat-ui/components/presentational/MultilineInput.tsx
+++ b/src/webchat-ui/components/presentational/MultilineInput.tsx
@@ -87,7 +87,7 @@ const MultilineInput = forwardRef<HTMLTextAreaElement, IMultilineInputProps>((pr
 							data-test={dataTest}
 							ref={ref}
 							className={`${className} ${disabled ? "disabled" : ""}`.trim()}
-							style={matches ? { fontSize: "16px" } : undefined}
+							style={matches ? { fontSize: "1rem" } : undefined}
 						/>
 					</InputContainer>
 				)}


### PR DESCRIPTION
This PR replaces leftover px to rem font sizes in input fields

# Success criteria
- px is replaced with rem in input fields

# How to test

Please describe the individual steps on how a peer can test your change.

1. Do a text-only zoom in your browser. (in chrome: Settings > Appearance > Font-size)
2. Enter some text in the message input field
3. See if the entered text has a size relative to your preferred size configured in your browser
4. Reduce the size of the window to be less than 575px and check the computed size of the text in the text area. It should be equal to your preferred font size

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
