### PR TITLE
ESM Build Target + Npm Packaging Config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,6 @@
 				"license-checker": "25.0.1",
 				"lodash": "^4.17.21",
 				"moment": "^2.29.4",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1",
 				"react-hot-toast": "^2.4.1",
 				"react-markdown": "^9.0.3",
 				"react-modal": "^3.16.3",
@@ -75,6 +73,8 @@
 				"idempotent-babel-polyfill": "^7.4.4",
 				"npm-run-all": "^4.1.5",
 				"prettier": "^3.5.3",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0",
 				"redux-devtools-extension": "^2.13.8",
 				"style-loader": "^3.3.1",
 				"terser-webpack-plugin": "^5.3.0",
@@ -89,6 +89,10 @@
 			},
 			"engines": {
 				"node": ">=22.1.0"
+			},
+			"peerDependencies": {
+				"react": "^18.3.0 || ^19.0.0",
+				"react-dom": "^18.3.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cognigy/webchat",
 	"version": "3.28.0",
-	"description": "Webchat Widget for Cognigy.AI",
+	"description": "Webchat for Cognigy.AI",
 	"author": "Cognigy GmbH <info@cognigy.com>",
 	"contributors": [
 		"Robin Schuster <r.schuster@cognigy.com>"
@@ -19,9 +19,12 @@
 		"./LICENSE",
 		"OSS_LICENSES.txt"
 	],
+	"publishConfig": {
+		"access": "public"
+	},
 	"scripts": {
-		"build": "npm run build:cjs && npm run build:esm",
-		"build:cjs": "webpack --config webpack.production.js",
+		"build": "npm run build:umd && npm run build:esm",
+		"build:umd": "webpack --config webpack.production.js",
 		"build:esm": "webpack --config webpack.es.js",
 		"update-license": "node update-license.js",
 		"dev": "webpack-dev-server --config webpack.dev.js --host 0.0.0.0",
@@ -33,6 +36,7 @@
 		"test:cypress": "run-p -r cypress:serve cypress:run",
 		"test:cypress:firefox": "run-p -r cypress:serve cypress:run:firefox",
 		"test": "npm run test:cypress",
+		"prepack": "npm run build && npm run update-license",
 		"pretest": "npm run build",
 		"prettier:check": "prettier --check .",
 		"prettier:fix": "prettier --write .",
@@ -56,8 +60,6 @@
 		"license-checker": "25.0.1",
 		"lodash": "^4.17.21",
 		"moment": "^2.29.4",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
 		"react-hot-toast": "^2.4.1",
 		"react-markdown": "^9.0.3",
 		"react-modal": "^3.16.3",
@@ -73,6 +75,10 @@
 		"tinycolor2": "1.6.0",
 		"uifx": "^2.0.7",
 		"uuid": "9.0.1"
+	},
+	"peerDependencies": {
+		"react": "^18.3.0 || ^19.0.0",
+		"react-dom": "^18.3.0 || ^19.0.0"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.16.7",
@@ -108,6 +114,8 @@
 		"idempotent-babel-polyfill": "^7.4.4",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^3.5.3",
+		"react": "^18.3.0",
+		"react-dom": "^18.3.0",
 		"redux-devtools-extension": "^2.13.8",
 		"style-loader": "^3.3.1",
 		"terser-webpack-plugin": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,22 @@
 		"Robin Schuster <r.schuster@cognigy.com>"
 	],
 	"license": "SEE LICENSE IN LICENSE",
-	"main": "lib/webchat/index.js",
+	"main": "dist/webchat.js",
+	"module": "dist/webchat.esm.js",
+	"exports": {
+		"import": "./dist/webchat.esm.js",
+		"require": "./dist/webchat.js"
+	},
+	"files": [
+		"./dist/webchat.esm.js",
+		"./dist/webchat.js",
+		"./LICENSE",
+		"OSS_LICENSES.txt"
+	],
 	"scripts": {
-		"build": "webpack --config webpack.production.js",
+		"build": "npm run build:cjs && npm run build:esm",
+		"build:cjs": "webpack --config webpack.production.js",
+		"build:esm": "webpack --config webpack.es.js",
 		"update-license": "node update-license.js",
 		"dev": "webpack-dev-server --config webpack.dev.js --host 0.0.0.0",
 		"cypress:open": "cypress open --e2e --browser chrome",

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -108,3 +108,5 @@ window.initWebchat = initWebchat;
 window.__COGNIGY_WEBCHAT = {
 	React,
 };
+
+export { initWebchat };

--- a/webpack.es.js
+++ b/webpack.es.js
@@ -1,0 +1,54 @@
+const webpack = require("webpack");
+const config = require("./webpack.config");
+const path = require("path");
+const { version } = require("./package.json");
+
+config.mode = "production";
+config.plugins.push(
+	new webpack.BannerPlugin({
+		banner: `[file] v${version}\nhttps://github.com/Cognigy/Webchat/tree/v${version}\nhttps://github.com/Cognigy/Webchat/tree/v${version}/OSS_LICENSES.txt`,
+	}),
+);
+
+config.mode = "production";
+config.output = {
+	path: path.resolve(__dirname, "dist"),
+	filename: "webchat.esm.js",
+	library: {
+		type: "module",
+	},
+	module: true,
+	environment: {
+		module: true,
+		dynamicImport: true,
+		destructuring: true,
+	},
+};
+config.experiments = {
+	outputModule: true,
+};
+config.resolve = {
+	...config.resolve,
+	mainFields: ["module", "main"],
+	fallback: {
+		tty: false,
+		util: false,
+		os: false,
+	},
+};
+
+config.optimization = {
+	concatenateModules: false,
+	minimize: false,
+	runtimeChunk: false,
+	splitChunks: false,
+	usedExports: true,
+};
+
+config.externalsType = "module";
+config.externals = {
+	react: "react",
+	"react-dom": "react-dom",
+};
+
+module.exports = config;


### PR DESCRIPTION
# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

- You can use Webchat as ES module:
```
<script type="module">
import {initWebchat} from "@cognigy/webchat"

initWebchat("endpoint");
</script>
```
- It is currently not possible to use Webchat module inside the React 19 application. This will be tackled in a follow-up.

# How to test

Please describe the individual steps on how a peer can test your change.

1. `npm pack`
2. then, outside of the Webchat dir, use `npm create vite@latest` to scaffold an application
3. install webchat package into it
4. try the script snippet above to init the webchat

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
