### PR TITLE
Channel Name Customization

### DIFF
--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -51,7 +51,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 		const baseUrl = getEndpointBaseUrl(url);
 		const token = getEndpointUrlToken(url);
 		const socketOptions = {
-			channel: "webchat-client",
+			channel: options?.channel || "webchat3",
 			...options,
 		};
 


### PR DESCRIPTION
This PR allows providing custom channel name for analytics. It also changes the default channel name to be the same we have in service-endpoint.

Previously, service-endpoint would have always override the channel name to "webchat3". Now, as it will also allow channel customization, we bring this in sync. For the users no change is actually happening unless they explicitly provide a custom channel name.