### PR TITLE
Remove Compressed Assets Generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,8 @@ jobs:
               with:
                   draft: true
                   files: |
-                      dist/*.js
-                      dist/*.gz
-                      dist/*.br
+                      dist/webchat.js
+                      dist/webchat.esm.js
                       OSS_LICENSES.txt
                   body: |
                       ### Potentially breaking changes

--- a/webpack.es.js
+++ b/webpack.es.js
@@ -51,4 +51,10 @@ config.externals = {
 	"react-dom": "react-dom",
 };
 
+config.plugins.push(
+	new webpack.optimize.LimitChunkCountPlugin({
+		maxChunks: 1,
+	}),
+);
+
 module.exports = config;

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -4,38 +4,11 @@ const { version } = require("./package.json");
 const config = require("./webpack.config");
 
 const TerserPlugin = require("terser-webpack-plugin");
-const zlib = require("zlib");
-const CompressionPlugin = require("compression-webpack-plugin");
 
 config.mode = "production";
 config.plugins.push(
 	new webpack.BannerPlugin({
 		banner: `[file] v${version}\nhttps://github.com/Cognigy/Webchat/tree/v${version}\nhttps://github.com/Cognigy/Webchat/tree/v${version}/OSS_LICENSES.txt`,
-	}),
-);
-
-config.plugins.push(
-	new CompressionPlugin({
-		filename: "[path][base].gz",
-		algorithm: "gzip",
-		test: /\.(js|css|html|svg|ts|tsx)$/,
-		threshold: 10240,
-		minRatio: 0.8,
-	}),
-);
-
-config.plugins.push(
-	new CompressionPlugin({
-		filename: "[path][base].br",
-		algorithm: "brotliCompress",
-		test: /\.(js|css|html|svg|ts|tsx)$/,
-		compressionOptions: {
-			params: {
-				[zlib.constants.BROTLI_PARAM_QUALITY]: 11,
-			},
-		},
-		threshold: 10240,
-		minRatio: 0.8,
 	}),
 );
 


### PR DESCRIPTION
# Success criteria

- When building Webchat, no more .gz, .br files are generated
- We include only relevant files with the GitHub release 
- When building, no more unused chunks are generated (no more xxx.chunk.js files)

# How to test

Please describe the individual steps on how a peer can test your change.

1. `npm ci && npm run build`
2. check PR diff

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

- Check if mention webchat.js.gz / webchat.js.br files anywhere, remove the mention if any.