### PR TITLE
Trigger the npm publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,8 @@ jobs:
             - name: Get release version
               id: get-version
               run: |
-                  RELEASE_VERSION="${GITHUB_REF#refs/tags/v}"
+                  TAG_NAME="${{ github.event.release.tag_name }}"
+                  RELEASE_VERSION="${TAG_NAME#v}"
                   if [ -z "$RELEASE_VERSION" ]; then
                     echo "No release version found."
                     exit 1


### PR DESCRIPTION
It should trigger the npm publish workflow automatically.

Sanity check, please. No possible to test until merge. 