### PR TITLE
Fix message visibility with progressive rendering

### DIFF
--- a/src/webchat/store/messages/message-reducer.ts
+++ b/src/webchat/store/messages/message-reducer.ts
@@ -62,6 +62,15 @@ const getFinishReason = (message: IMessage, messageId?: string) => {
 	return messageId ? (message.data?._cognigy as CognigyData)?._finishReason : "stop";
 };
 
+// Helper to determine if a message should be set as the currently animating message
+const shouldSetAsAnimating = (
+	nextAnimatingId: string | null,
+	newMessage: IMessage,
+	isEngagementMessageHidden: boolean,
+) => {
+	return !nextAnimatingId && !(newMessage.source === "engagement" && isEngagementMessageHidden);
+};
+
 // slice of the store state that contains the info about streaming mode and teaserMessage, to avoid circular dependency
 type ConfigState = {
 	settings?: {
@@ -126,7 +135,13 @@ export const createMessageReducer = (getState: () => { config: ConfigState }) =>
 					if (!state.currentlyAnimatingId) {
 						visibleOutputMessages.push(newMessageId as string);
 					}
-					if (!nextAnimatingId && !(newMessage.source === "engagement" && isEngagementMessageHidden)) {
+
+					const shouldAnimate = shouldSetAsAnimating(
+						nextAnimatingId,
+						newMessage,
+						isEngagementMessageHidden,
+					);
+					if (shouldAnimate) {
 						nextAnimatingId = isAnimated ? newMessageId : null;
 					}
 
@@ -167,7 +182,12 @@ export const createMessageReducer = (getState: () => { config: ConfigState }) =>
 					newMessageId = generateRandomId();
 				}
 
-				if (!nextAnimatingId && !(newMessage.source === "engagement" && isEngagementMessageHidden)) {
+				const shouldAnimate = shouldSetAsAnimating(
+					nextAnimatingId,
+					newMessage,
+					isEngagementMessageHidden,
+				);
+				if (shouldAnimate) {
 					nextAnimatingId = newMessageId;
 				}
 


### PR DESCRIPTION
This PR fixes an issue where bot messages that arrive immediately after the teaser message is not displayed in the chat-log

# Success criteria

Please describe what should be possible after this change. List all individual items on a separate line.

-  bot messages should be displayed in chatlog when progressive rendering and teaser message enabled

# How to test

Please describe the individual steps on how a peer can test your change.

**Pre-requisite:** 
Simply use this endpoint for testing: https://endpoint-dev.cognigy.ai/110645e0a5eea23040bc0bd70bcdabdba6390d666a95b0beb85e788c0624754b

(OR)

1. Create a flow with some say node outputs 
2. Create an v3 webchat endpoint with progressive rendering and teaser message enabled
3. Disable 'Show teaser message in chat'
4. Additionally, Add LLM Prompt nodes with stream to output mode

**Testing:**
1. Connect webchat to the endpoint and wait for the teaser message to arrive
2. After the teaser message arrived, open the chat log
3. You should see the message outputs from the say nodes being animated
5. If you test the same endpoint with the [latest version of webchat](https://webchat-testing.vercel.app/), you will notice that the say node outputs are not being displayed in the log
6. Please also test the same by enabling 'Show teaser message in chat' or opeing the chat before the arrival of teaser message
7. Additionally, test it 'Stream to Output' node setting with collation endpoint setting on/off

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

These are hints for the documentation team to help write the docs.
