### PR TITLE
chore: update @cognigy/socket-client to 5.0.0-beta.26, bump version to 3.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.40.0",
+	"version": "3.41.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/webchat",
-			"version": "3.40.0",
+			"version": "3.41.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",
 				"@cognigy/chat-components": "0.69.0",
-				"@cognigy/socket-client": "5.0.0-beta.25",
+				"@cognigy/socket-client": "5.0.0-beta.26",
 				"@emotion/cache": "^10.0.29",
 				"@emotion/react": "^11.13.0",
 				"@emotion/serialize": "1.3.0",
@@ -1974,9 +1974,9 @@
 			}
 		},
 		"node_modules/@cognigy/socket-client": {
-			"version": "5.0.0-beta.25",
-			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.25.tgz",
-			"integrity": "sha512-r9zOdWcu2EJfmVVGQhe2exOdFeJtp/lj+qfMTGQ478PqbNKNV6ojeXW8s4bKMAxTYKLrJ1uB7YRi4OgEBdaV6A==",
+			"version": "5.0.0-beta.26",
+			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.26.tgz",
+			"integrity": "sha512-gM068L2vaHZTKH3X5G0W9RzB/VaOjUnesTdQJIwhCpzJOO3gmQYSlf7iSow6Tx0CUz5boYkC45yyWucuDfucIQ==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"detect-browser": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.40.0",
+	"version": "3.41.0",
 	"description": "Webchat for Cognigy.AI",
 	"author": "Cognigy GmbH <info@cognigy.com>",
 	"contributors": [
@@ -55,7 +55,7 @@
 	"dependencies": {
 		"@braintree/sanitize-url": "^6.0.0",
 		"@cognigy/chat-components": "0.69.0",
-		"@cognigy/socket-client": "5.0.0-beta.25",
+		"@cognigy/socket-client": "5.0.0-beta.26",
 		"@emotion/cache": "^10.0.29",
 		"@emotion/react": "^11.13.0",
 		"@emotion/serialize": "1.3.0",


### PR DESCRIPTION
## Changes

- Updated `@cognigy/socket-client` from `5.0.0-beta.25` to `5.0.0-beta.26`
- Bumped Webchat version from `3.40.0` to `3.41.0`

### Socket Client Changes (v5.0.0-beta.26)
- Vulnerability fixes (relock package-lock.json)
- Merged from [SocketClient PR #73](https://github.com/Cognigy/SocketClient/pull/73)