### PR TITLE
Fix: trigger preview deploy on ready_for_review

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -19,7 +19,7 @@ name: PR Preview Deploy
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened]
+        types: [opened, synchronize, reopened, ready_for_review]
 
 # Only allow one deploy per PR at a time; cancel in-progress runs for the same PR
 concurrency:


### PR DESCRIPTION
## Summary

- The `deploy-preview` job guards on `draft == false`, but the workflow only triggered on `opened`, `synchronize`, and `reopened` events
- When a PR was created as a draft and later marked ready for review, the `ready_for_review` event was not handled, so no workflow run was triggered and the deploy stayed permanently skipped (e.g. PR #263)
- Adds `ready_for_review` to the `pull_request` event types so the deploy runs when a draft PR is promoted

## Test plan

- [ ] Create a draft PR, verify deploy-preview is skipped
- [ ] Mark the PR as "Ready for review", verify deploy-preview runs