### PR TITLE
fix: webchat.open() should always open, not toggle

### DIFF
--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -127,7 +127,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 			this.store.dispatch(showChatScreen());
 		}
 
-		this.store.dispatch(toggleOpen());
+		this.store.dispatch(setOpen(true));
 	};
 
 	open = async () => {


### PR DESCRIPTION
  ## Problem
  Calling `webchat.open()` while the chat was already open would minimise it.

  This broke any programmatic caller button which calls `open()` on every click, and minimises it when chatbot UI 
  should have it open.

  ## Cause  
  `_open()` was dispatching `toggleOpen()`. The UI middleware handles this by flipping the current state
  (`setOpen(!open)`), so a second call while open would close it. 

  ## Fix 
  Changed `_open()` to dispatch `setOpen(true)` directly. The `toggle()` method is a separate API and still uses
  `toggleOpen()` as expected.

  **File:** `src/webchat/components/Webchat.tsx`

  ## Testing
  | Scenario | Before | After |  
  |--|--|--|
  | open() while closed | Opens correctly | Opens correctly |
  | open() while already open | Closes - fail | Stays open |
  | open() called 3× in a row | Closes - fail | Stays open |
  | close() / toggle() | Unaffected | Unaffected | 

  # Success criteria 

  - Calling `webchat.open()` while the chat is already open keeps it open  
  - Calling `webchat.open()` multiple times in a row does not close the chat
  - `webchat.close()` and `webchat.toggle()` continue to behave as expected

  # How to test

  1. Embed the webchat on a page and initialise it 
  2. Call `webchat.open()` — confirm the chat opens
  3. Call `webchat.open()` a second time while the chat is visible — confirm it stays open and does not minimise  
  4. Call `webchat.close()` — confirm the chat closes 
  5. Call `webchat.toggle()` — confirm it opens, call again and confirm it closes

All the testing above has passed after my fix.

  # Security

  - [ ] Possible injection vector
  - [ ] Authentication/Access controls touched
  - [ ] Sensitive Data could be exposed
  - [ ] XSS
  - [ ] Logging/Monitoring touched
  - [ ] Exchanges data with external systems
  - [X] No security implications

  # Additional considerations

  - [ ] This PR might have performance implications

  # Documentation Considerations

  These are hints for the documentation team to help write the docs.