### PR TITLE
Add region role for Chat History

### DIFF
--- a/cypress/e2e/chatLog.cy.ts
+++ b/cypress/e2e/chatLog.cy.ts
@@ -26,4 +26,8 @@ describe("Chat Log", () => {
 		cy.get("#webchatChatHistoryWrapperLiveLogPanel").focus();
 		cy.get(".webchat-chat-history").should("have.css", "outline", "rgb(59, 103, 233) auto 2px");
 	});
+
+	it("chat log panel has region role", () => {
+		cy.get("#webchatChatHistoryWrapperLiveLogPanel").should("have.attr", "role", "region");
+	});
 });

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -155,6 +155,7 @@ export function ChatScroller({
 			<ChatLog
 				ref={innerRef}
 				id="webchatChatHistoryWrapperLiveLogPanel"
+				role="region"
 				tabIndex={isChatLogOverflowing() ? 0 : -1}
 				aria-labelledby="webchatChatHistoryHeading"
 				onFocus={handleFocus}


### PR DESCRIPTION
This is a minor accessibility improvement adding a `role="region"` landmark to the chat log container (`ChatScroller`). 

`role="log"` was considered but rejected: that role implies `aria-live="polite"` behaviour, causing screen readers to automatically announce every new message appended to the container. The Webchat already has a dedicated `ScreenReaderLiveRegion` component (`src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx`) that manages live announcements with `aria-live="polite"`. Using `role="log"` on the scroll container would duplicate those announcements and create a noisy, unpredictable screen reader experience. Adding `aria-live="off"` to suppress the implicit live behaviour of `role="log"` was also considered, but browser and screen reader support for overriding a role's implicit `aria-live` value is inconsistent — some screen readers ignore the override and announce anyway. On the other hand, `role="region"` gives the area a named landmark without implying any live-region behaviour. 

# Success criteria

- The chat log container in the Webchat UI is correctly identified as a landmark region by assistive technologies
- Screen readers announce the chat history area as a "region" landmark, labelled by the existing `webchatChatHistoryHeading` element
- Users navigating by landmarks (e.g. via screen reader shortcut) can jump directly to the chat log

# How to test

1. Open the Webchat UI in a browser with a screen reader enabled (e.g. NVDA + Firefox, or VoiceOver + Safari)
2. Use the screen reader's landmark navigation shortcut to list or cycle through page regions
3. Verify that the chat history area appears as a named region (e.g. "Chat History, region" or similar, depending on the screen reader)
4. Confirm that the chat log content is accessible and that the region label matches the heading text tied to `webchatChatHistoryHeading`

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications


