### PR TITLE
AB#120092 Screen-reader fix for data-only messages

### DIFF
--- a/cypress/e2e/screenReaderLiveRegion.cy.ts
+++ b/cypress/e2e/screenReaderLiveRegion.cy.ts
@@ -1,0 +1,51 @@
+describe("Screen Reader Live Region", () => {
+	const liveRegionSelector = "#webchatMessageContainerScreenReaderLiveRegion";
+
+	beforeEach(() => {
+		cy.visitWebchat();
+		cy.initMockWebchat();
+		cy.openWebchat().startConversation();
+	});
+
+	it("announces a rendered text message", () => {
+		cy.receiveMessage("Hello there");
+
+		// Wait past the 100ms debounce in ScreenReaderLiveRegion.
+		cy.wait(500);
+		cy.get(liveRegionSelector).should("contain", "Hello there");
+	});
+
+	it("does not announce a data-only message that is not rendered in the chat log", () => {
+		// A message with no text and a payload that matches no renderable plugin
+		// is data-only: it produces no <article> in the DOM.
+		cy.receiveMessage("", { some: "data-only-payload" }, "bot");
+
+		cy.wait(500);
+
+		// The data-only message produces no rendered message node...
+		cy.get("article").should("have.length", 0);
+		// ...and must NOT be announced with the generic fallback.
+		cy.get(liveRegionSelector).should("not.contain", "A new message");
+	});
+
+	it("skips a data-only message but still announces a later rendered message", () => {
+		// Interleave a data-only message between two real text messages. This
+		// guards the index-0 blocking edge case: a non-rendered message at the
+		// front of the queue must not block announcement of later messages.
+		cy.receiveMessage("First message");
+		cy.wait(500);
+		cy.get(liveRegionSelector).should("contain", "First message");
+
+		cy.receiveMessage("", { some: "data-only-payload" }, "bot");
+		cy.receiveMessage("Second message");
+
+		cy.wait(500);
+
+		// Only the two text messages render in the chat log.
+		cy.get("article").should("have.length", 2);
+		// The later text message is still announced...
+		cy.get(liveRegionSelector).should("contain", "Second message");
+		// ...and the data-only message never triggered the generic fallback.
+		cy.get(liveRegionSelector).should("not.contain", "A new message");
+	});
+});

--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "../../../webchat/helper/useSelector";
-import { cleanUpText, getTextFromDOM } from "../../utils/live-region-announcement";
+import {
+	cleanUpText,
+	getTextFromDOM,
+	messageElementExists,
+} from "../../utils/live-region-announcement";
 import getMessagesListWithoutControlCommands from "../../utils/filter-out-control-commands";
 import { IStreamingMessage } from "../../../common/interfaces/message";
 
@@ -37,32 +41,46 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 		};
 
 		const timeout = setTimeout(() => {
-			const firstUnannouncedMsg = unannouncedMessages[0]; // Only announce one at a time
-			const id = `webchatMessageId-${firstUnannouncedMsg.timestamp}`;
+			// Scan for the first unannounced message that is currently announceable.
+			// We must NOT stop at index 0 for non-rendered (data-only) messages,
+			// otherwise a permanently data-only message would block all later ones.
+			for (const candidate of unannouncedMessages) {
+				const id = `webchatMessageId-${candidate.timestamp}`;
 
-			// Check if this is a streaming message that hasn't finished
-			const isStreaming =
-				isProgressiveRenderingEnabled &&
-				isStreamingMessage(firstUnannouncedMsg) &&
-				(firstUnannouncedMsg.animationState === "start" ||
-					firstUnannouncedMsg.animationState === "animating");
+				// A streaming message that hasn't finished blocks later announcements
+				// (preserves in-order announcement of streamed output).
+				const isStreaming =
+					isProgressiveRenderingEnabled &&
+					isStreamingMessage(candidate) &&
+					(candidate.animationState === "start" ||
+						candidate.animationState === "animating");
+				if (isStreaming) return;
 
-			// If streaming, don't announce yet
-			if (isStreaming) return;
+				// Event status pills announce themselves via aria-live="assertive".
+				// Mark handled and continue; they must not block later real messages.
+				if (liveContent[id] === `IGNORE-${id}`) {
+					announcedIdsRef.current.add(id);
+					continue;
+				}
 
-			announcedIdsRef.current.add(id);
+				// "Rendered" iff chat-components produced live content for it,
+				// or an <article data-message-id> node exists in the DOM.
+				const isRendered = Boolean(liveContent[id]) || messageElementExists(id);
 
-			// Skip announcement if the message is marked as "IGNORE". Done by ChatEvent message component, as it has aria-live="assertive"
-			if (liveContent[id] === `IGNORE-${id}`) {
-				setLiveMessage(null);
+				// Data-only / unsupported message: not in the chat log UI.
+				// Skip WITHOUT marking announced so it can still be announced
+				// if it becomes rendered later (e.g. progressive rendering).
+				if (!isRendered) {
+					continue;
+				}
+
+				// Rendered: announce exactly one message per effect run.
+				announcedIdsRef.current.add(id);
+				const rawText = liveContent[id] || getTextFromDOM(id);
+				const text = cleanUpText(rawText || "A new message");
+				setLiveMessage({ id, text });
 				return;
 			}
-
-			// Use live content if available, otherwise extract from DOM
-			const rawText = liveContent[id] || getTextFromDOM(id);
-			const text = cleanUpText(rawText || "A new message");
-
-			setLiveMessage({ id, text });
 		}, 100);
 
 		return () => clearTimeout(timeout);

--- a/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
+++ b/src/webchat-ui/components/presentational/ScreenReaderLiveRegion.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "../../../webchat/helper/useSelector";
-import {
-	cleanUpText,
-	getTextFromDOM,
-	messageElementExists,
-} from "../../utils/live-region-announcement";
+import { cleanUpText, getTextFromDOM } from "../../utils/live-region-announcement";
 import getMessagesListWithoutControlCommands from "../../utils/filter-out-control-commands";
 import { IStreamingMessage } from "../../../common/interfaces/message";
 
@@ -63,9 +59,15 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 					continue;
 				}
 
+				// Prefer chat-components' live content; otherwise read the DOM.
+				// getTextFromDOM returns null when no <article data-message-id>
+				// node exists, which is the signal for a not-rendered message.
+				const liveText = liveContent[id];
+				const domText = liveText ? null : getTextFromDOM(id);
+
 				// "Rendered" iff chat-components produced live content for it,
 				// or an <article data-message-id> node exists in the DOM.
-				const isRendered = Boolean(liveContent[id]) || messageElementExists(id);
+				const isRendered = Boolean(liveText) || domText !== null;
 
 				// Data-only / unsupported message: not in the chat log UI.
 				// Skip WITHOUT marking announced so it can still be announced
@@ -75,9 +77,9 @@ const ScreenReaderLiveRegion: React.FC<ScreenReaderLiveRegionProps> = ({ liveCon
 				}
 
 				// Rendered: announce exactly one message per effect run.
+				// Fall back to "A new message" for rendered-but-textless nodes.
 				announcedIdsRef.current.add(id);
-				const rawText = liveContent[id] || getTextFromDOM(id);
-				const text = cleanUpText(rawText || "A new message");
+				const text = cleanUpText(liveText || domText || "A new message");
 				setLiveMessage({ id, text });
 				return;
 			}

--- a/src/webchat-ui/utils/live-region-announcement.ts
+++ b/src/webchat-ui/utils/live-region-announcement.ts
@@ -92,3 +92,15 @@ export const getTextFromDOM = (id: string): string => {
 		? extractTextForScreenReader(messageElement as HTMLElement)
 		: "A new message";
 };
+
+/**
+ * Returns true if a message is actually rendered in the chat log DOM.
+ * The <article data-message-id="..."> node only exists when chat-components'
+ * Message matcher matched at least one plugin. Data-only / unsupported
+ * messages produce no DOM node, so this returns false for them.
+ *
+ * @param id - The message ID (e.g. "webchatMessageId-<timestamp>")
+ */
+export const messageElementExists = (id: string): boolean => {
+	return document.querySelector(`[data-message-id="${id}"]`) !== null;
+};

--- a/src/webchat-ui/utils/live-region-announcement.ts
+++ b/src/webchat-ui/utils/live-region-announcement.ts
@@ -83,24 +83,15 @@ export const extractTextForScreenReader = (root: HTMLElement): string => {
  * - Querying the DOM for the element with the specified ID
  * - Using the extractTextForScreenReader function to get the text content
  *
- * @param id - The message ID to extract text for
- * @returns The extracted text or a default message if not found
- */
-export const getTextFromDOM = (id: string): string => {
-	const messageElement = document.querySelector(`[data-message-id="${id}"]`);
-	return messageElement
-		? extractTextForScreenReader(messageElement as HTMLElement)
-		: "A new message";
-};
-
-/**
- * Returns true if a message is actually rendered in the chat log DOM.
  * The <article data-message-id="..."> node only exists when chat-components'
  * Message matcher matched at least one plugin. Data-only / unsupported
- * messages produce no DOM node, so this returns false for them.
+ * messages produce no DOM node, so callers can use a `null` return to tell a
+ * not-rendered message apart from a rendered-but-textless one.
  *
- * @param id - The message ID (e.g. "webchatMessageId-<timestamp>")
+ * @param id - The message ID to extract text for
+ * @returns The extracted text, or `null` if no element exists for the id
  */
-export const messageElementExists = (id: string): boolean => {
-	return document.querySelector(`[data-message-id="${id}"]`) !== null;
+export const getTextFromDOM = (id: string): string | null => {
+	const messageElement = document.querySelector(`[data-message-id="${id}"]`);
+	return messageElement ? extractTextForScreenReader(messageElement as HTMLElement) : null;
 };


### PR DESCRIPTION
# Success criteria

After this change:

- Data-only messages (messages with no visible content — e.g. a `data`-only payload that is not rendered in the chat log) are **no longer announced** by screen readers. Previously they were announced as the generic "A new message".
- Every message that **is** visible in the chat log continues to be announced exactly as before (text, text-with-buttons, gallery, list, image, video, audio, file, adaptive card).
- A data-only message that arrives **before** a visible message does not block the visible message from being announced. The later visible message is still announced.
- Event status pills (e.g. "agent joined") continue to announce via their own `aria-live="assertive"` region and are not double-announced. A real message arriving right after a pill is still announced.
- Streaming / progressively-rendered messages still announce only once they finish rendering, in order.
- The generic "A new message" announcement is still used as a fallback for messages that **are** rendered in the chat log but have no extractable text (e.g. an image with no alternative text).

# How to test

> The screen-reader announcement lives in a visually-hidden `aria-live="polite"` region with id `webchatMessageContainerScreenReaderLiveRegion`. To inspect it without a screen reader, open DevTools and watch the text content of that element (it is `class="sr-only"`, so it is not visible on screen but is present in the DOM). For a true accessibility check, use a real screen reader (NVDA on Windows, VoiceOver on macOS, or TalkBack on Android).

You can use this endpoint to test scenario 1, 2 and 3 https://endpoint-dev.cognigy.ai/4e55e43cdde3df2c7c2640b3e727e184722b349e802fa565efa3de1aa56f6ef6

## Scenario 1 — Regression: a normal message is still announced
1. Open the webchat and start a conversation.
2. Have the bot send a plain **text** message (e.g. "Hello there").
3. **Expected:** the message is read aloud by the screen reader (and the `#webchatMessageContainerScreenReaderLiveRegion` element contains the message text).
4. Repeat for other visible message types — quick replies (text with buttons), gallery, list, image, video, audio, file, adaptive card — and confirm each is announced as before this change.

## Scenario 2 — Core fix: a data-only message is NOT announced
1. Open the webchat and start a conversation.
2. Trigger a **data-only message** — a message with no rendered output in the chat log. For example, a bot/flow output that only carries `data` (custom payload) and no text or supported template, so nothing appears in the chat window.
3. **Expected:**
   - Nothing new appears in the chat log (no message bubble).
   - The screen reader stays **silent** — it must **not** announce "A new message".
   - In DevTools, `#webchatMessageContainerScreenReaderLiveRegion` does not contain "A new message".

## Scenario 3 — A data-only message does not block a later visible message
1. Open the webchat and start a conversation.
2. Have the bot send a visible **text** message ("First message"). Confirm it is announced.
3. Have the bot send a **data-only message** (as in Scenario 2), immediately followed by another visible **text** message ("Second message").
4. **Expected:**
   - Only the two text messages appear in the chat log (the data-only message renders nothing).
   - The screen reader announces "Second message".
   - "A new message" is **never** announced.

## Scenario 4 — Event status pills still behave correctly
1. Trigger a flow that produces an event status pill (e.g. an agent joining / "handover" event).
2. **Expected:**
   - The pill is announced once via its own assertive live region (unchanged behavior).
   - A real bot/agent message sent right after the pill is still announced normally.

## Automated tests
New Cypress spec `cypress/e2e/screenReaderLiveRegion.cy.ts` covers Scenarios 1–3:
```bash
npm run test:cypress:chrome -- --spec "cypress/e2e/screenReaderLiveRegion.cy.ts"
```

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

No documentation changes required. This is an accessibility bug fix to the screen-reader live-region announcements; the observable behavior change is that non-rendered data-only messages are no longer announced.

---

Replaces #269 (same issue, [AB#120092](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/120092)). This implementation additionally fixes an edge case where a data-only or event message at the front of the announcement queue could block a later visible message from being announced, and adds Cypress coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
