### PR TITLE
fix: preserve file attachments when input collation is enabled (AB#106774)

### DIFF
--- a/cypress/e2e/collated-file-inputs.cy.ts
+++ b/cypress/e2e/collated-file-inputs.cy.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for AB#106774 — "File Upload Issue with input collation enabled".
+ *
+ * When input collation is enabled, the collation middleware used to rebuild the
+ * collated message with `data: undefined`, which discarded the uploaded file
+ * attachments (`data.attachments`). As a result no file payload reached the flow.
+ * These tests assert that attachments survive collation.
+ */
+describe("collated file inputs", () => {
+	const fileAttachment = {
+		runtimeFileId: "runtime-file-1",
+		fileName: "myfile.txt",
+		mimeType: "text/plain",
+		size: 13,
+		url: "https://storage.example/myfile.txt",
+	};
+
+	const secondAttachment = {
+		runtimeFileId: "runtime-file-2",
+		fileName: "myfile2.txt",
+		mimeType: "text/plain",
+		size: 14,
+		url: "https://storage.example/myfile2.txt",
+	};
+
+	const initCollationWebchat = () =>
+		cy
+			.initMockWebchat({
+				settings: {
+					layout: {
+						enableInputCollation: true,
+					},
+				},
+			})
+			.openWebchat()
+			.startConversation();
+
+	beforeEach(() => {
+		cy.visitWebchat();
+	});
+
+	it("keeps file attachments on the submitted message when collation is enabled", () => {
+		initCollationWebchat();
+
+		cy.sendMessage("here is the file", { attachments: [fileAttachment] }, "user", {
+			collate: true,
+		});
+
+		cy.getMessageFromHistory(
+			(message: any) =>
+				message.source === "user" &&
+				message.text === "here is the file" &&
+				message.data?.attachments?.length === 1 &&
+				message.data.attachments[0].fileName === "myfile.txt",
+		);
+	});
+
+	it("keeps attachments for an attachment-only message (no text)", () => {
+		initCollationWebchat();
+
+		cy.sendMessage("", { attachments: [fileAttachment] }, "user", { collate: true });
+
+		cy.getMessageFromHistory(
+			(message: any) => message.source === "user" && message.data?.attachments?.length === 1,
+		);
+	});
+
+	it("merges attachments from multiple collated inputs into a single message", () => {
+		initCollationWebchat();
+
+		// text typed first, then a file uploaded within the collation window:
+		// the attachment lives in a *later* buffered message and must not be lost.
+		cy.sendMessage("look", undefined, "user", { collate: true });
+		cy.sendMessage("at this", { attachments: [fileAttachment, secondAttachment] }, "user", {
+			collate: true,
+		});
+
+		cy.getMessageFromHistory(
+			(message: any) =>
+				message.source === "user" &&
+				message.text === "look at this" &&
+				message.data?.attachments?.length === 2,
+		);
+	});
+});

--- a/src/webchat/store/input-collation/input-collation-middleware.ts
+++ b/src/webchat/store/input-collation/input-collation-middleware.ts
@@ -25,10 +25,21 @@ export const createInputCollationMiddleware = (): Middleware<object, StoreState>
 			const { messages } = store.getState().inputCollation;
 			const text = messages.map(message => message.text).join(" ");
 
+			/**
+			 * Preserve file upload attachments while collating. Each collatable input
+			 * carries its attachments in `data.attachments`, so we merge them across all
+			 * buffered messages. Without this, uploaded files are silently dropped when
+			 * input collation is enabled (no file payload reaches the flow).
+			 */
+			const attachments = messages.flatMap(message => {
+				const fileAttachments = message.data?.attachments;
+				return Array.isArray(fileAttachments) ? fileAttachments : [];
+			});
+
 			const message = {
 				...messages[0],
 				text,
-				data: undefined,
+				data: attachments.length > 0 ? { attachments } : undefined,
 			};
 
 			return message;


### PR DESCRIPTION
# Success criteria

- Uploading and sending a file in Webchat works when **Input collation** is enabled (the file payload reaches the flow / a socket event with the file input is emitted).
- The uploaded file is shown in the chat log when input collation is enabled.
- Files typed-then-uploaded within the collation window (attachment in a later buffered message) are preserved.
- Existing input collation behaviour for text-only messages is unchanged.

# How to test

1. Create a simple flow and a Webchat v3 endpoint; configure a file storage provider + connection (e.g. Azure Blob).
2. Enable **Input collation** under Layout → Advanced layout settings.
3. Open the demo Webchat, upload a file and send it.
4. The attachment appears in the chat log and a socket event with the file input is sent to the flow (previously: nothing was sent and the file was missing from the chat log).
5. Repeat with collation disabled to confirm parity.

Automated:
- `cypress/e2e/collated-file-inputs.cy.ts` — text+attachment, attachment-only, and multi-input attachment-merge cases.
- Regression: `collated-text-inputs.cy.ts` (12) and `fileAttachements.cy.ts` (10) still pass.

# Root cause

`getCollatedMessage()` in `input-collation-middleware.ts` rebuilt the collated message with `data: undefined`, discarding the uploaded file attachments carried in `data.attachments`. Downstream, `message-middleware` drops empty messages (`if (!text && !data) break;`), so an attachment-only upload produced no socket event at all. The workaround was to disable collation (`collate: false`), which bypasses this code path.

# Fix

Merge `data.attachments` across all buffered collatable messages and keep them on the collated message. `collate: true` is only ever set on the regular text/file input, whose `data` is only ever `null` or `{ attachments }`, so no other data (e.g. control commands) is affected. Text-only collation is unchanged.

# Security

- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

No documentation changes required — this restores the documented file-upload behaviour while input collation is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
