### PR TITLE
AB#138678 Add disableMobileScrollLock opt-out for mobile scroll lock

### DIFF
--- a/cypress/e2e/mobileScrollLock.cy.ts
+++ b/cypress/e2e/mobileScrollLock.cy.ts
@@ -1,0 +1,55 @@
+// Verifies the `widgetSettings.disableMobileScrollLock` opt-out (AZ 138678).
+// When the webchat is open on a mobile viewport it locks scrolling of the host
+// page via react-remove-scroll, which sets `data-scroll-locked` on <body>.
+// The flag must disable that lock, and must react to runtime updateSettings().
+
+const MOBILE = [375, 700] as const;
+const DESKTOP = [1280, 900] as const;
+
+describe("Mobile scroll lock (disableMobileScrollLock)", () => {
+	it("locks host-page scroll on mobile when open (default behavior)", () => {
+		cy.viewport(...MOBILE);
+		cy.visitWebchat().initMockWebchat();
+		cy.openWebchat();
+
+		cy.get("[data-cognigy-webchat]").should("exist");
+		cy.get("body").should("have.attr", "data-scroll-locked");
+	});
+
+	it("does NOT lock host-page scroll when disableMobileScrollLock is true", () => {
+		cy.viewport(...MOBILE);
+		cy.visitWebchat().initMockWebchat({
+			settings: { widgetSettings: { disableMobileScrollLock: true } },
+		});
+		cy.openWebchat();
+
+		cy.get("[data-cognigy-webchat]").should("exist");
+		cy.get("body").should("not.have.attr", "data-scroll-locked");
+	});
+
+	it("never locks on a desktop viewport regardless of the flag", () => {
+		cy.viewport(...DESKTOP);
+		cy.visitWebchat().initMockWebchat();
+		cy.openWebchat();
+
+		cy.get("[data-cognigy-webchat]").should("exist");
+		cy.get("body").should("not.have.attr", "data-scroll-locked");
+	});
+
+	it("reacts to updateSettings() at runtime without a reload", () => {
+		cy.viewport(...MOBILE);
+		cy.visitWebchat().initMockWebchat();
+		cy.openWebchat();
+
+		// locked by default
+		cy.get("body").should("have.attr", "data-scroll-locked");
+
+		// flip the flag on -> lock released live
+		cy.updateSettings({ widgetSettings: { disableMobileScrollLock: true } });
+		cy.get("body").should("not.have.attr", "data-scroll-locked");
+
+		// flip it back off -> lock re-applied live
+		cy.updateSettings({ widgetSettings: { disableMobileScrollLock: false } });
+		cy.get("body").should("have.attr", "data-scroll-locked");
+	});
+});

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -383,6 +383,7 @@ _These settings are NOT configurable via the Endpoint Editor in Cognigy.AI_
 | disableTextInputSanitization | boolean | `false` | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc. |
 | disableToggleButton | boolean | `false` | Disable the Webchat Toggle Button |
 | disableTeaserMarkdownRemoval | boolean | `false` | Disable the automatic removal of Markdown in the Teaser Message. |
+| disableMobileScrollLock | boolean | `false` | When the webchat is open on a mobile-sized viewport it locks scrolling of the underlying host page. Set this to true to opt out of that behavior, e.g. when the host page shows its own scrollable overlay such as a cookie-consent banner that would otherwise become unreachable. |
 | enableAutoFocus | boolean | `false` | If true, focus will be automatically moved to the first focusable element within the latest incoming message. Ths focus will only be moved when the focus is currently on an element within the chat log. |
 | enableInjectionWithoutEmptyHistory | boolean | `false` | If true, will not prevent the auto-inject start behavior from being triggered if the history is not empty |
 | enableFocusTrap | boolean | `false` | If true, elements outside the chat window will not be focusable during keyboard navigation when the chat window is open |
@@ -836,6 +837,7 @@ interface IWebchatSettings {
 		disableTextInputSanitization: boolean;
 		disableToggleButton: boolean;
 		disableTeaserMarkdownRemoval: boolean;
+		disableMobileScrollLock: boolean;
 		enableAutoFocus: boolean;
 		enableInjectionWithoutEmptyHistory: boolean;
 		enableFocusTrap: boolean;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -427,6 +427,13 @@ export interface IWebchatSettings {
 		disableTextInputSanitization: boolean;
 		disableToggleButton: boolean;
 		disableTeaserMarkdownRemoval: boolean;
+		/**
+		 * When the webchat is open on a mobile-sized viewport it locks scrolling of the
+		 * underlying host page (via react-remove-scroll). Set this to `true` to opt out of
+		 * that behavior, e.g. when the host page shows its own scrollable overlay such as a
+		 * cookie-consent banner that would otherwise become unreachable.
+		 */
+		disableMobileScrollLock: boolean;
 		enableAutoFocus: boolean;
 		enableInjectionWithoutEmptyHistory: boolean;
 		enableFocusTrap: boolean;

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1039,7 +1039,7 @@ export class WebchatUI extends React.PureComponent<
 		const { theme, hadConnection, lastUnseenMessageText, wasOpen, isMobile } = state;
 
 		const {
-			widgetSettings: { disableToggleButton },
+			widgetSettings: { disableToggleButton, disableMobileScrollLock },
 			behavior: { enableConnectionStatusIndicator },
 		} = config.settings;
 
@@ -1141,7 +1141,10 @@ export class WebchatUI extends React.PureComponent<
 					{/* <Global styles={cssReset} /> */}
 					<>
 						{/* @ts-expect-error - react-remove-scroll typings require `children` even though JSX children are provided correctly */}
-						<RemoveScroll enabled={open && isMobile} allowPinchZoom={true}>
+						<RemoveScroll
+							enabled={open && isMobile && !disableMobileScrollLock}
+							allowPinchZoom={true}
+						>
 							<WebchatWrapper
 								data-cognigy-webchat-root
 								{...restProps}

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -183,7 +183,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 		this.client.on("output", handler);
 	};
 
-	updateSettings = (settings: IWebchatSettings) => {
+	updateSettings = (settings: Partial<IWebchatSettings>) => {
 		this.store.dispatch(updateSettings(settings));
 	};
 

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -187,6 +187,7 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 			disableTextInputSanitization: false,
 			disableToggleButton: false,
 			disableTeaserMarkdownRemoval: false,
+			disableMobileScrollLock: false,
 			enableAutoFocus: false,
 			enableInjectionWithoutEmptyHistory: false,
 			enableFocusTrap: false,


### PR DESCRIPTION
## What & why

**AZ 138678 (NS Groep, top5):** On mobile, when the webchat opens fullscreen it locks scrolling of the **host page** via `react-remove-scroll`. NS's cookie-consent banner (OneTrust, rendered in the host document at max z-index) then can't be scrolled to its consent buttons, so mobile users get stuck and can't dismiss it.

Root cause: [`WebchatUI.tsx`](../blob/claude/interesting-villani-24e330/src/webchat-ui/components/WebchatUI.tsx) wraps the UI in `<RemoveScroll enabled={open && isMobile}>`, whose document-level `touchmove`/`wheel` handlers cancel scroll gestures anywhere outside the webchat subtree — including the host's banner. Verified live on `www.ns.nl`: with the chat open on a mobile viewport, `body[data-scroll-locked]` is set and touch-drag inside OneTrust's scrollable `#ot-pc-content` is cancelled (`defaultPrevented: true`).

## The change

Add a `widgetSettings.disableMobileScrollLock` flag (**default `false`** — existing behavior unchanged) that gates the lock:

```diff
- <RemoveScroll enabled={open && isMobile} allowPinchZoom={true}>
+ <RemoveScroll enabled={open && isMobile && !disableMobileScrollLock} allowPinchZoom={true}>
```

- The flag is read in `render()`, so it's reactive — embedders can toggle it **live** via the existing `updateSettings()` API (no reload). Releasing/re-applying the lock unmounts/remounts react-remove-scroll's side-effect.
- `updateSettings()`'s parameter is widened to `Partial<IWebchatSettings>` to match the deep-merge the reducer already performs.
- Documented in `docs/embedding.md` (Widget Settings table + interface listing).

NS (or any embedder with a host overlay) sets `widgetSettings.disableMobileScrollLock: true`, or toggles it at runtime while a consent banner is showing.

## Verification

- **Types:** `tsc` error set byte-identical before/after (zero new errors).
- **Runtime (new Cypress spec, 4/4 passing in Chrome):** locked by default (mobile + open) · not locked with the flag · never locked on desktop · live toggle via `updateSettings()`.

## Follow-up (not in this PR)

A durable, zero-config fix for the whole customer base: pass known CMP containers (OneTrust `#onetrust-consent-sdk`, Cookiebot, Usercentrics, Didomi) as react-remove-scroll `shards` so their internal scroll is preserved while the rest of the page stays locked. This PR is the immediate opt-out unblock; the shards work is the proper follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
