### PR TITLE
feat: add webchat/close-button analytics event for explicit header close

### DIFF
--- a/cypress/e2e/closeButtonAnalytics.cy.ts
+++ b/cypress/e2e/closeButtonAnalytics.cy.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression coverage for the `webchat/close-button` analytics event.
+ *
+ * Background: the header close ("X") button and the toggle button (FAB) both
+ * collapse the Webchat and both emit `webchat/close`. Integrations that end the
+ * session on `webchat/close` therefore also end it when the user simply toggles
+ * the widget shut. The dedicated `webchat/close-button` event fires ONLY for the
+ * header close button, so integrations can distinguish an intentional close.
+ *
+ * These tests assert the event fires for the header X and for nothing else
+ * (toggle button, minimize, programmatic open/close/toggle).
+ */
+
+type AnalyticsEvent = { type: string; payload?: any };
+
+/** Register a collector that records every analytics event emitted from now on. */
+const collectEvents = (events: AnalyticsEvent[]) =>
+	cy.getWebchat().then((webchat: any) => {
+		webchat.registerAnalyticsService((event: AnalyticsEvent) => events.push(event));
+	});
+
+/** Open the Webchat and advance past the home screen into the chat screen. */
+const openChatScreen = () => cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
+
+const typesOf = (events: AnalyticsEvent[]) => events.map(event => event.type);
+
+describe("Analytics: webchat/close-button event", () => {
+	it("emits 'webchat/close-button' when the header close (X) button is clicked", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen();
+		collectEvents(events);
+
+		cy.get("[data-header-close-button]").click();
+
+		cy.then(() => {
+			const closeButtonEvents = events.filter(event => event.type === "webchat/close-button");
+			expect(closeButtonEvents, "exactly one webchat/close-button event").to.have.length(1);
+		});
+	});
+
+	it("still emits the generic 'webchat/close' alongside it (backward compatible)", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen();
+		collectEvents(events);
+
+		cy.get("[data-header-close-button]").click();
+
+		cy.then(() => {
+			const types = typesOf(events);
+			expect(types, "header X must still emit webchat/close").to.include("webchat/close");
+			expect(types, "header X must also emit webchat/close-button").to.include(
+				"webchat/close-button",
+			);
+		});
+	});
+
+	it("does NOT emit 'webchat/close-button' when collapsing via the toggle button", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen();
+		collectEvents(events);
+
+		// Clicking the FAB while open collapses the chat (the user's reported scenario).
+		cy.get("#webchatWindowToggleButton").click();
+
+		cy.wait(200);
+		cy.then(() => {
+			const types = typesOf(events);
+			expect(types, "toggle should still emit webchat/close").to.include("webchat/close");
+			expect(types, "toggle must NOT emit webchat/close-button").to.not.include(
+				"webchat/close-button",
+			);
+		});
+	});
+
+	it("does NOT emit 'webchat/close-button' when minimizing", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen();
+		collectEvents(events);
+
+		cy.get("[data-header-minimize-button]").click();
+
+		cy.wait(200);
+		cy.then(() => {
+			const types = typesOf(events);
+			expect(types, "minimize emits webchat/minimize").to.include("webchat/minimize");
+			expect(types, "minimize must NOT emit webchat/close-button").to.not.include(
+				"webchat/close-button",
+			);
+			expect(types, "minimize must NOT emit webchat/close").to.not.include("webchat/close");
+		});
+	});
+
+	it("does NOT emit 'webchat/close-button' from the home screen close button (it minimizes)", () => {
+		const events: AnalyticsEvent[] = [];
+		// Home screen enabled: opening lands on the home screen (no startConversation).
+		cy.visitWebchat().initMockWebchat({ settings: { homeScreen: { enabled: true } } });
+		cy.openWebchat();
+		collectEvents(events);
+
+		cy.get(".webchat-homescreen-close-button").click();
+
+		cy.wait(200);
+		cy.then(() => {
+			const types = typesOf(events);
+			expect(types, "home screen close emits webchat/minimize").to.include(
+				"webchat/minimize",
+			);
+			expect(types, "home screen close must NOT emit webchat/close-button").to.not.include(
+				"webchat/close-button",
+			);
+		});
+	});
+
+	it("does NOT emit 'webchat/close-button' via the programmatic webchat.close() API", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen();
+		collectEvents(events);
+
+		cy.getWebchat().then((webchat: any) => webchat.close());
+
+		cy.wait(200);
+		cy.then(() => {
+			const types = typesOf(events);
+			expect(types, "webchat.close() emits webchat/close").to.include("webchat/close");
+			expect(types, "webchat.close() must NOT emit webchat/close-button").to.not.include(
+				"webchat/close-button",
+			);
+		});
+	});
+
+	it("does NOT emit 'webchat/close-button' via the programmatic webchat.toggle() API", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen();
+		collectEvents(events);
+
+		cy.getWebchat().then((webchat: any) => webchat.toggle()); // open -> closed
+
+		cy.wait(200);
+		cy.then(() => {
+			const types = typesOf(events);
+			expect(types, "toggle() emits webchat/close").to.include("webchat/close");
+			expect(types, "toggle() must NOT emit webchat/close-button").to.not.include(
+				"webchat/close-button",
+			);
+		});
+	});
+
+	it("does NOT emit 'webchat/close-button' when opening", () => {
+		const events: AnalyticsEvent[] = [];
+		cy.visitWebchat().initMockWebchat();
+		collectEvents(events);
+
+		cy.openWebchat().startConversation();
+
+		cy.wait(200);
+		cy.then(() => {
+			const types = typesOf(events);
+			expect(types, "opening emits webchat/open").to.include("webchat/open");
+			expect(types, "opening must NOT emit webchat/close-button").to.not.include(
+				"webchat/close-button",
+			);
+		});
+	});
+});
+
+describe("Analytics: end-session use case (docs/analytics-api.md example)", () => {
+	/**
+	 * Mirrors the documented integration: end the session ONLY on the header
+	 * close button. Spies on `webchat.endSession` and wires the documented
+	 * handler, then asserts which UI interactions trigger it.
+	 */
+	const wireEndSessionOnCloseButton = () =>
+		cy.getWebchat().then((webchat: any) => {
+			cy.spy(webchat, "endSession").as("endSession");
+			webchat.registerAnalyticsService((event: AnalyticsEvent) => {
+				if (event.type === "webchat/close-button") {
+					webchat.endSession();
+				}
+			});
+		});
+
+	it("ends the session when the header close (X) button is used", () => {
+		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
+		wireEndSessionOnCloseButton();
+
+		cy.get("[data-header-close-button]").click();
+
+		cy.get("@endSession").should("have.been.calledOnce");
+	});
+
+	it("does NOT end the session when collapsing via the toggle button", () => {
+		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
+		wireEndSessionOnCloseButton();
+
+		cy.get("#webchatWindowToggleButton").click();
+
+		cy.wait(200);
+		cy.get("@endSession").should("not.have.been.called");
+	});
+
+	it("does NOT end the session when minimizing", () => {
+		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
+		wireEndSessionOnCloseButton();
+
+		cy.get("[data-header-minimize-button]").click();
+
+		cy.wait(200);
+		cy.get("@endSession").should("not.have.been.called");
+	});
+});

--- a/docs/analytics-api.md
+++ b/docs/analytics-api.md
@@ -23,11 +23,11 @@ Anytime an event is being emitted within the Webchat, it will cause the passed c
 The `event` object will always have a `type` property and may have a `payload` property depending on the event.
 By checking for `event.type`, you can filter events for the ones you are interested in.
 
-If you e.g. want to end session when user closes the webchat widget, you can do it like this:
+If you e.g. want to end the session when the user closes the Webchat widget using the header close ("X") button, listen for the `webchat/close-button` event:
 
 ```javascript
 webchat.registerAnalyticsService(event => {
-	if (event.type === "webchat/close") {
+	if (event.type === "webchat/close-button") {
 		webchat.endSession();
 	}
 });
@@ -35,17 +35,21 @@ webchat.registerAnalyticsService(event => {
 
 This will end the current session and clear any messages from the session.
 
+> [!NOTE]
+> Use `webchat/close-button` rather than `webchat/close` for this. The `webchat/close` event also fires when the user collapses the open chat with the toggle button (the chat icon in the corner of the page) and when you call `webchat.close()` or `webchat.toggle()`, so ending the session on `webchat/close` would also end it on every toggle. The `webchat/close-button` event fires **only** when a header close ("X") button is used — both the chat window header and the connection-lost (disconnect) overlay. The home screen's close button and the header minimize button emit `webchat/minimize` (never `webchat/close-button`), so they do not end the session.
+
 ## Webchat Events
 
-| Type                       | Payload          | Description                                                  |
-| -------------------------- | ---------------- | ------------------------------------------------------------ |
-| `webchat/open`             | -                | The webchat was opened                                       |
-| `webchat/close`            | -                | The webchat was closed                                       |
-| `webchat/minimize`         | -                | The webchat was minimized                                    |
-| `webchat/switch-session`   | `sessionId`      | The session was switched                                     |
-| `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy                          |
-| `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy                                |
-| `plugin/messenger/action`  | `Object`         | An action was triggered from a Webchat or Messenger Template |
+| Type                       | Payload          | Description                                                                                                                                                                                                                        |
+| -------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `webchat/open`             | -                | The webchat was opened                                                                                                                                                                                                             |
+| `webchat/close`            | -                | The webchat was closed — fires for a header close ("X") button, the toggle button, and the `webchat.close()` / `webchat.toggle()` APIs (but not for minimizing)                                                                    |
+| `webchat/close-button`     | -                | The webchat was closed via a header close ("X") button — the chat window header or the disconnect overlay. Does not fire for the toggle button, the home screen close (which minimizes), or `webchat.close()` / `webchat.toggle()` |
+| `webchat/minimize`         | -                | The webchat was minimized                                                                                                                                                                                                          |
+| `webchat/switch-session`   | `sessionId`      | The session was switched                                                                                                                                                                                                           |
+| `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy                                                                                                                                                                                                |
+| `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy                                                                                                                                                                                                      |
+| `plugin/messenger/action`  | `Object`         | An action was triggered from a Webchat or Messenger Template                                                                                                                                                                       |
 
 See it in action:  
 [![Edit Analytics API](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/using-the-webchat-api-ho5nk?fontsize=14&hidenavigation=1&theme=dark)

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -984,6 +984,23 @@ export class WebchatUI extends React.PureComponent<
 		}
 	};
 
+	/**
+	 * Emits the `webchat/close-button` analytics event.
+	 *
+	 * Fired only from the close ("X") button handlers — the chat window header
+	 * (`handleCloseAndReset`) and the disconnect overlay (`handleClose`). It is
+	 * NOT emitted for the toggle button, the home-screen close (which minimizes),
+	 * or the programmatic `webchat.close()` / `webchat.toggle()` APIs.
+	 *
+	 * This lives in the component rather than the redux analytics middleware
+	 * (where `webchat/open|close|minimize` are emitted) on purpose: the store only
+	 * sees the resulting `SET_OPEN` action and cannot tell which control triggered
+	 * the close, so the originating interaction is only known here.
+	 */
+	emitCloseButtonAnalytics = () => {
+		this.props.onEmitAnalytics("webchat/close-button");
+	};
+
 	render() {
 		const { props, state } = this;
 		const {
@@ -1132,6 +1149,9 @@ export class WebchatUI extends React.PureComponent<
 
 		const handleClose = () => {
 			onClose();
+			// The disconnect overlay's close ("X") is also a header close button, so
+			// it emits "webchat/close-button" for parity with the chat window header.
+			this.emitCloseButtonAnalytics();
 			this.chatToggleButtonRef.current?.focus();
 		};
 
@@ -1340,6 +1360,10 @@ export class WebchatUI extends React.PureComponent<
 		const handleCloseAndReset = () => {
 			onSetShowHomeScreen(true);
 			onClose();
+			// `onClose()` emits the generic "webchat/close" (which also fires for the
+			// toggle button); this additionally emits "webchat/close-button" so
+			// integrations can react to an explicit header close only.
+			this.emitCloseButtonAnalytics();
 			// Restore focus to chat toggle button
 			this.chatToggleButtonRef?.current?.focus?.();
 		};


### PR DESCRIPTION
# Success criteria

- Integrations can detect when a user closes the Webchat via a header close ("X") button specifically, via a new `webchat/close-button` analytics event.
- Ending the session on `webchat/close-button` does NOT also fire when the user collapses the chat with the toggle button (the chat icon in the corner), minimizes, or when `webchat.close()` / `webchat.toggle()` are called programmatically — this fixes the reported issue where clicking the widget icon ended the session.
- The existing `webchat/close` event is unchanged (still fires for both the header X and the toggle button), so existing integrations keep working.
- The disconnect-overlay close ("X") behaves like the chat window header close (also emits `webchat/close-button`).

# How to test

1. Embed the Webchat and register an analytics handler: `webchat.registerAnalyticsService(e => console.log(e.type))`.
2. Open the chat and start a conversation, then click the header **X** → observe both `webchat/close` and `webchat/close-button`.
3. Open again, then click the **toggle button** (chat icon) to collapse → observe `webchat/close` only (no `webchat/close-button`).
4. Open again, click **minimize** → observe `webchat/minimize` only.
5. Automated: run `cypress/e2e/closeButtonAnalytics.cy.ts` (11 tests) — covers every close path plus the documented end-session use case. Existing `webchatButton` / `homeScreen` specs still pass.

# Security

- [x] No security implications

# Additional considerations

- [ ] This PR might have performance implications

No performance impact: the change adds a single synchronous analytics event emit on the close interaction.

# Documentation Considerations

- New analytics event `webchat/close-button` is documented in `docs/analytics-api.md` (events table + NOTE explaining how it differs from `webchat/close`).
- The recommended pattern for "end the session when the user closes the widget" is now `webchat/close-button` instead of `webchat/close`. Customers currently ending the session on `webchat/close` should switch to `webchat/close-button` to avoid ending the session when the widget icon is toggled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
