### PR TITLE
fix(a11y): prevent Safari layout break on reverse keyboard nav (AB#105695)

### DIFF
--- a/cypress/e2e/chatLog.cy.ts
+++ b/cypress/e2e/chatLog.cy.ts
@@ -34,19 +34,41 @@ describe("Chat Log", () => {
 	// AB#105695 — On Safari/WebKit, focusing an element during (reverse) keyboard navigation made
 	// the browser scroll the `overflow: hidden` #webchatWindow shell to bring it into view, leaving
 	// a stuck offset that shifted the header up and broke the layout. The window must never hold a
-	// scroll offset — its onScroll handler snaps it back to the origin. We can't reproduce WebKit's
-	// focus-scroll quirk in headless Chrome, so we assert the guarantee directly: any scroll of the
-	// window is reset to 0.
+	// scroll offset — its onScroll handler snaps it back to the origin.
+	//
+	// We can't reproduce WebKit's focus-scroll quirk in headless Chrome, and the window can't
+	// actually hold an offset here (its inner chat log absorbs all overflow, so scrollHeight ===
+	// clientHeight and the browser clamps any scrollTop straight back to 0). So we exercise the
+	// wired-up handler directly: make the node *report* a non-zero scrollTop, fire the same native
+	// `scroll` event WebKit would, and assert the handler resets it. This fails if the onScroll
+	// handler is removed or stops clamping — unlike a plain `scrollTop = 80` assignment, which the
+	// browser clamps to 0 before the handler ever runs (so it would pass even with no fix).
 	it("keeps the webchat window pinned to its scroll origin", () => {
 		cy.withMessageFixture("adaptivecard", () => {
-			// Simulate what WebKit's scroll-into-view does to the window.
+			// Precondition: the window genuinely can't scroll here — assigning an offset is clamped
+			// to 0 immediately, which is why a naive assignment can't drive this test.
 			cy.get("#webchatWindow").then($win => {
 				const win = $win[0];
 				win.scrollTop = 80;
-				win.dispatchEvent(new Event("scroll", { bubbles: false }));
+				expect(win.scrollTop, "window cannot hold a scroll offset").to.equal(0);
 			});
-			cy.get("#webchatWindow").should($win => {
-				expect($win[0].scrollTop).to.equal(0);
+
+			// Stub scrollTop so the node reports the offset WebKit's scroll-into-view would leave,
+			// then fire the real native `scroll` event the handler listens for. React 18 attaches
+			// onScroll as a native listener on this node, so the actual handler runs.
+			cy.get("#webchatWindow").then($win => {
+				const win = $win[0];
+				let reported = 69; // observed WebKit nudge
+				Object.defineProperty(win, "scrollTop", {
+					configurable: true,
+					get: () => reported,
+					set: v => {
+						reported = v;
+					},
+				});
+				win.dispatchEvent(new Event("scroll", { bubbles: false }));
+
+				expect(reported, "onScroll handler snaps the window back to origin").to.equal(0);
 			});
 		});
 	});

--- a/cypress/e2e/chatLog.cy.ts
+++ b/cypress/e2e/chatLog.cy.ts
@@ -30,4 +30,33 @@ describe("Chat Log", () => {
 	it("chat log panel has region role", () => {
 		cy.get("#webchatChatHistoryWrapperLiveLogPanel").should("have.attr", "role", "region");
 	});
+
+	// AB#105695 — On Safari/WebKit, focusing an element during (reverse) keyboard navigation made
+	// the browser scroll the `overflow: hidden` #webchatWindow shell to bring it into view, leaving
+	// a stuck offset that shifted the header up and broke the layout. The window must never hold a
+	// scroll offset — its onScroll handler snaps it back to the origin. We can't reproduce WebKit's
+	// focus-scroll quirk in headless Chrome, so we assert the guarantee directly: any scroll of the
+	// window is reset to 0.
+	it("keeps the webchat window pinned to its scroll origin", () => {
+		cy.withMessageFixture("adaptivecard", () => {
+			// Simulate what WebKit's scroll-into-view does to the window.
+			cy.get("#webchatWindow").then($win => {
+				const win = $win[0];
+				win.scrollTop = 80;
+				win.dispatchEvent(new Event("scroll", { bubbles: false }));
+			});
+			cy.get("#webchatWindow").should($win => {
+				expect($win[0].scrollTop).to.equal(0);
+			});
+		});
+	});
+
+	describe("Accessibility (WCAG 2.2 AA)", () => {
+		it("has no detectable a11y violations when the log is scrollable and focused", () => {
+			cy.withMessageFixture("adaptivecard", () => {
+				cy.get("#webchatChatHistoryWrapperLiveLogPanel").focus();
+				cy.checkA11yCompliance("[data-cognigy-webchat-root]");
+			});
+		});
+	});
 });

--- a/cypress/fixtures/messages/adaptivecard-webchat.json
+++ b/cypress/fixtures/messages/adaptivecard-webchat.json
@@ -25,15 +25,18 @@
 							"images": [
 								{
 									"type": "Image",
-									"url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg"
+									"url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg",
+									"altText": "Steak"
 								},
 								{
 									"type": "Image",
-									"url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg"
+									"url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg",
+									"altText": "Chicken"
 								},
 								{
 									"type": "Image",
-									"url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg"
+									"url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg",
+									"altText": "Tofu"
 								}
 							]
 						}

--- a/cypress/fixtures/messages/adaptivecard.json
+++ b/cypress/fixtures/messages/adaptivecard.json
@@ -24,15 +24,18 @@
 						"images": [
 							{
 								"type": "Image",
-								"url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg"
+								"url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg",
+								"altText": "Steak"
 							},
 							{
 								"type": "Image",
-								"url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg"
+								"url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg",
+								"altText": "Chicken"
 							},
 							{
 								"type": "Image",
-								"url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg"
+								"url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg",
+								"altText": "Tofu"
 							}
 						]
 					}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -861,6 +861,25 @@ export class WebchatUI extends React.PureComponent<
 		}
 	};
 
+	/**
+	 * The webchat window (#webchatWindow) is a fixed-size flex shell with `overflow: hidden`; its
+	 * children (header, chat log, input) manage their own scrolling. Safari/WebKit, however, still
+	 * scrolls an `overflow: hidden` ancestor to bring a newly focused element into view — so during
+	 * (reverse) keyboard navigation it nudges the whole window by a few pixels, shifting the header
+	 * up and clipping the layout. Nothing else resets it, so the broken offset sticks (AB#105695).
+	 * Snap the window back to its origin whenever it is scrolled. This is browser- and message-type
+	 * agnostic and never interferes with the inner scroll containers.
+	 */
+	handleWebchatWindowScroll: React.UIEventHandler<HTMLDivElement> = event => {
+		// Only act on the window's own scroll, never on a descendant scroll container that might
+		// surface here. React 18 does not bubble synthetic scroll events, but this keeps the
+		// target-only intent explicit and resilient to any future change in event delegation.
+		if (event.target !== event.currentTarget) return;
+		const el = event.currentTarget;
+		if (el.scrollTop !== 0) el.scrollTop = 0;
+		if (el.scrollLeft !== 0) el.scrollLeft = 0;
+	};
+
 	handleSendRating = ({ rating, comment, showRatingStatus }) => {
 		this.props.onShowRatingScreen(false);
 
@@ -1189,6 +1208,7 @@ export class WebchatUI extends React.PureComponent<
 												className="webchat"
 												id="webchatWindow"
 												ref={this.webchatWindowRef}
+												onScroll={this.handleWebchatWindowScroll}
 												chatWindowWidth={
 													this.props.config.settings.layout
 														.chatWindowWidth


### PR DESCRIPTION
## Summary

Fixes a layout break on **Safari/WebKit** during reverse keyboard navigation in a scrollable chat ([AB#105695](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/105695)). The chat content shifts up and the header gets clipped, and the broken state persists across subsequent forward navigation. It reproduces **with and without** a screen reader, and is **independent of message type**.

## Root cause

The top-level webchat window (`#webchatWindow`, the `WebchatRoot` flex shell) is styled `overflow: hidden`. Unlike `overflow: clip`, an `overflow: hidden` element is still programmatically scrollable, and **Safari/WebKit scrolls it to bring a newly focused element into view** when focus lands during (reverse) keyboard navigation.

This nudges the whole window by a few pixels (observed `scrollTop: ~69`), shifting the header up and clipping the layout. Nothing ever resets that offset:

- the chat log's own scroll effect only runs on message/config changes, so it never corrects the window offset;
- the offset is on the *window*, not the chat log, so forward navigation afterward doesn't recover it.

The window is a fixed-size shell that is **never meant to scroll** — all real scrolling happens in the inner `overflow: auto` containers (the chat log and the content wrapper).

## Fix

Add an `onScroll` handler on `#webchatWindow` that snaps it back to its scroll origin (`scrollTop`/`scrollLeft` → 0). A target-only guard (`event.target !== event.currentTarget`) ensures descendant scroll containers are never affected.

This is:
- **Browser-agnostic** — it reacts to the scroll itself, so it neutralizes the WebKit nudge regardless of trigger.
- **Message-type agnostic** — fixes the bug for every message type, matching the reported behavior.
- **Non-interfering** — React 18 attaches `onScroll` directly to the node and doesn't bubble synthetic scroll events, so the inner chat-log/file-preview/menu scrolling never reaches this handler (verified). Tabbing to a control inside an off-screen message still scrolls it into view via the chat log's own scroll container.

## Before behavior

<!-- REVIEWER NOTE / PR author: drag-and-drop the "before" screenshot here. -->
<!-- (Header "You're now chatting with an AI Agent" pushed up and clipped at the top after reverse → forward nav on Safari.) -->
_Before: the header is pushed up and the layout is clipped after reverse navigation on Safari (screenshot below)._
<img width="565" height="936" alt="Screenshot from 2026-06-29 10-16-49" src="https://github.com/user-attachments/assets/1c2834e5-e6af-4e24-9d63-953b2da7b984" />



## How to test

> ⚠️ The bug is **WebKit-specific** — it must be tested on **Safari** . It does **not** reproduce in Chrome/Firefox.

Set up a conversation long enough that the chat log overflows and the chat is scrollable (e.g. trigger several messages / an adaptive card / gallery).

**1. Without a screen reader (Safari, macOS)**
1. Tab **forward** into the chat until focus is inside the chat log or input field.
2. **Shift+Tab** (reverse navigation) back up through the chat log so the scrollable region / an off-screen control receives focus.
3. Then **Tab forward** again.
4. ✅ Expected: the header and overall layout stay put; no upward shift or clipping. (Before the fix, the layout breaks and stays broken.)

**2. With a screen reader (VoiceOver, Safari)**
1. Enable VoiceOver (`Cmd+F5`).
2. Navigate **forward** into the chat log with `VO + →` (Control+Option+Right).
3. Navigate **backward** with `VO + ←` (reverse nav) until the chat log region / an earlier control is focused.
4. Navigate **forward** again.
5. ✅ Expected: layout remains stable throughout; the header is not pushed up or clipped, and content stays correctly positioned.

**3. Regression sanity (any browser)**
- Tab to a button/link inside a message that is currently scrolled off-screen → it should still scroll into view normally (handled by the chat log's own scroll, not the window).
- Normal vertical scrolling of the chat log (mouse/keyboard/touch) should be unaffected.

## Tests

- Added a regression test asserting the webchat window stays pinned to its scroll origin.
- Added a WCAG 2.2 AA (`checkA11yCompliance`) assertion on the focused, scrollable chat log.

Both live in `cypress/e2e/chatLog.cy.ts`.

## Risk

Low. The window is architecturally non-scrolling; clamping it to 0 only removes a stuck offset and cannot hide otherwise-unreachable content. Inner scroll containers, RTL layouts, and the mobile scroll lock are all unaffected (each operates on a different element).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
