### PR TITLE
Release/3.46.0

### DIFF
--- a/OSS_LICENSES.txt
+++ b/OSS_LICENSES.txt
@@ -1,4 +1,4 @@
-Created on 29-06-2026 at 10:14:48
+Created on 02-07-2026 at 14:08:29
 
 {
   "@babel/code-frame@7.29.0": {
@@ -170,7 +170,7 @@ Created on 29-06-2026 at 10:14:48
     "licenseFile": "node_modules/@cognigy/socket-client/LICENSE",
     "copyright": "Copyright (c) 2019 Cognigy GmbH"
   },
-  "@cognigy/webchat@3.45.0": {
+  "@cognigy/webchat@3.46.0": {
     "licenses": "MIT*",
     "repository": "https://github.com/Cognigy/Webchat",
     "publisher": "Cognigy GmbH",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.45.0",
+	"version": "3.46.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/webchat",
-			"version": "3.45.0",
+			"version": "3.46.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.45.0",
+	"version": "3.46.0",
 	"description": "Webchat for Cognigy.AI",
 	"author": "Cognigy GmbH <info@cognigy.com>",
 	"contributors": [


### PR DESCRIPTION
## Release/3.46.0

Minor release cut from `main`, published to the `pre-release` dist-tag.

### Dependencies
No dependency bumps this release — all pinned versions are already current:
- `@cognigy/chat-components` `0.76.0` (latest)
- `@cognigy/socket-client` `5.0.0-beta.26` (beta tag)
- `axios` `1.18.1`

### Bug Fixes
- fix(a11y): prevent Safari layout break on reverse keyboard nav ([AB#105695](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/105695)) (#288)

### Chore
- Regenerated `OSS_LICENSES.txt` for v3.46.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
