### PR TITLE
feat(analytics): connection status on webchat/close-button + webchat.disconnect() (AB#142965)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/index.html
 
 cypress/screenshots
 cypress/videos
+cypress/downloads
 .DS_Store
 
 # Editor directories and files

--- a/cypress/e2e/closeButtonAnalytics.cy.ts
+++ b/cypress/e2e/closeButtonAnalytics.cy.ts
@@ -1,14 +1,20 @@
 /**
- * Regression coverage for the `webchat/close-button` analytics event.
+ * Coverage for the `webchat/close-button` analytics event and its payload.
  *
- * Background: the header close ("X") button and the toggle button (FAB) both
- * collapse the Webchat and both emit `webchat/close`. Integrations that end the
- * session on `webchat/close` therefore also end it when the user simply toggles
- * the widget shut. The dedicated `webchat/close-button` event fires ONLY for the
- * header close button, so integrations can distinguish an intentional close.
+ * The event fires from every header close ("X") button — the chat window
+ * header, the home screen, and the connection-lost (disconnect) overlay — and
+ * NOT from the toggle button (FAB), the minimize button, or the programmatic
+ * open/close/toggle APIs. Both the toggle button and the header X emit the
+ * generic `webchat/close`, so integrations that want an intentional-close
+ * signal rely on `webchat/close-button` instead.
  *
- * These tests assert the event fires for the header X and for nothing else
- * (toggle button, minimize, programmatic open/close/toggle).
+ * Its payload carries the connection status at close time
+ * (`{ connected, hadConnection }`) so integrations can act only when a session
+ * was actually active — the close button also appears on screens shown before
+ * the first connection (a first-visit home screen, privacy notice,
+ * previous-conversations) where `hadConnection` is false. These tests assert
+ * the emission rules, the payload values, the documented disconnect-on-close
+ * integration, and the `webchat.disconnect()` API it relies on.
  */
 
 type AnalyticsEvent = { type: string; payload?: any };
@@ -22,7 +28,49 @@ const collectEvents = (events: AnalyticsEvent[]) =>
 /** Open the Webchat and advance past the home screen into the chat screen. */
 const openChatScreen = () => cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
 
+/**
+ * The mock endpoint never opens a real socket, so drive the connection state
+ * through the store (as the `sendMessage` support command does).
+ */
+const setConnected = (connected: boolean) =>
+	cy.getWebchat().then((webchat: any) => {
+		webchat.store.dispatch({ type: "SET_CONNECTED", connected });
+	});
+
+/**
+ * Connect via the store, then gate (retriably) on the store reflecting it —
+ * rather than a fixed wait — so WebchatUI's `hadConnection` latch has committed
+ * before we act. `hadConnection` latches true when `connected` first becomes
+ * true and never resets.
+ */
+const connectAndLatch = () => {
+	setConnected(true);
+	cy.getWebchat().its("store").invoke("getState").its("connection.connected").should("be.true");
+};
+
+/**
+ * Render the connection-lost overlay by connecting then dropping. react-redux 7
+ * on React 18 commits the transient connected state asynchronously, and
+ * `hadConnection` (WebchatUI component state) has no observable while connected —
+ * so rather than bet on a fixed delay, retry the connect/drop until the overlay
+ * (which requires the `hadConnection` latch) actually renders. `hadConnection`
+ * latches on any connect and never resets, so this converges.
+ */
+const showDisconnectOverlayViaDrop = (attempt = 0) => {
+	setConnected(true);
+	cy.wait(50); // let react-redux 7 commit the connect so hadConnection can latch
+	setConnected(false);
+	cy.get("body").then($body => {
+		const shown = $body.find("[data-disconnect-overlay-close-button]").length > 0;
+		if (!shown && attempt < 20) {
+			showDisconnectOverlayViaDrop(attempt + 1);
+		}
+	});
+};
+
 const typesOf = (events: AnalyticsEvent[]) => events.map(event => event.type);
+const closeButtonEventsOf = (events: AnalyticsEvent[]) =>
+	events.filter(event => event.type === "webchat/close-button");
 
 describe("Analytics: webchat/close-button event", () => {
 	it("emits 'webchat/close-button' when the header close (X) button is clicked", () => {
@@ -33,7 +81,7 @@ describe("Analytics: webchat/close-button event", () => {
 		cy.get("[data-header-close-button]").click();
 
 		cy.then(() => {
-			const closeButtonEvents = events.filter(event => event.type === "webchat/close-button");
+			const closeButtonEvents = closeButtonEventsOf(events);
 			expect(closeButtonEvents, "exactly one webchat/close-button event").to.have.length(1);
 		});
 	});
@@ -90,7 +138,7 @@ describe("Analytics: webchat/close-button event", () => {
 		});
 	});
 
-	it("does NOT emit 'webchat/close-button' from the home screen close button (it minimizes)", () => {
+	it("emits 'webchat/close-button' from the home screen close button (alongside webchat/minimize)", () => {
 		const events: AnalyticsEvent[] = [];
 		// Home screen enabled: opening lands on the home screen (no startConversation).
 		cy.visitWebchat().initMockWebchat({ settings: { homeScreen: { enabled: true } } });
@@ -102,10 +150,10 @@ describe("Analytics: webchat/close-button event", () => {
 		cy.wait(200);
 		cy.then(() => {
 			const types = typesOf(events);
-			expect(types, "home screen close emits webchat/minimize").to.include(
+			expect(types, "home screen close still emits webchat/minimize").to.include(
 				"webchat/minimize",
 			);
-			expect(types, "home screen close must NOT emit webchat/close-button").to.not.include(
+			expect(types, "home screen close now also emits webchat/close-button").to.include(
 				"webchat/close-button",
 			);
 		});
@@ -163,48 +211,154 @@ describe("Analytics: webchat/close-button event", () => {
 	});
 });
 
-describe("Analytics: end-session use case (docs/analytics-api.md example)", () => {
+describe("Analytics: webchat/close-button payload (connection status)", () => {
+	it("reports { connected: false, hadConnection: false } on a screen that never connected", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen(); // the mock never establishes a connection
+		collectEvents(events);
+
+		cy.get("[data-header-close-button]").click();
+
+		cy.then(() => {
+			const [event] = closeButtonEventsOf(events);
+			expect(event?.payload).to.deep.equal({ connected: false, hadConnection: false });
+		});
+	});
+
+	it("reports { connected: true, hadConnection: true } while connected", () => {
+		const events: AnalyticsEvent[] = [];
+		openChatScreen();
+		connectAndLatch();
+		collectEvents(events);
+
+		cy.get("[data-header-close-button]").click();
+
+		cy.then(() => {
+			const [event] = closeButtonEventsOf(events);
+			expect(event?.payload).to.deep.equal({ connected: true, hadConnection: true });
+		});
+	});
+
+	it("reports { connected: false, hadConnection: true } from the disconnect overlay after the connection drops", () => {
+		const events: AnalyticsEvent[] = [];
+		cy.visitWebchat().initMockWebchat({
+			settings: { behavior: { enableConnectionStatusIndicator: true } },
+		});
+		cy.openWebchat().startConversation();
+		collectEvents(events);
+
+		// With the connection-status indicator on, a previously connected session
+		// that disconnects renders the connection-lost overlay. Reaching it proves
+		// hadConnection latched true while connected is now false.
+		showDisconnectOverlayViaDrop();
+		cy.get("[data-disconnect-overlay-close-button]").should("be.visible").click();
+
+		cy.then(() => {
+			const [event] = closeButtonEventsOf(events);
+			expect(event?.payload).to.deep.equal({ connected: false, hadConnection: true });
+		});
+	});
+});
+
+describe("Analytics: disconnect-on-close use case (docs/analytics-api.md example)", () => {
 	/**
-	 * Mirrors the documented integration: end the session ONLY on the header
-	 * close button. Spies on `webchat.endSession` and wires the documented
-	 * handler, then asserts which UI interactions trigger it.
+	 * Mirrors the documented integration: disconnect on the header close button,
+	 * but ONLY when a session was actually active (`event.payload.hadConnection`).
+	 * Spies on `webchat.disconnect`, wires the documented handler, then asserts
+	 * which interactions trigger it.
 	 */
-	const wireEndSessionOnCloseButton = () =>
+	const wireDisconnectOnCloseButton = () =>
 		cy.getWebchat().then((webchat: any) => {
-			cy.spy(webchat, "endSession").as("endSession");
+			cy.spy(webchat, "disconnect").as("disconnect");
 			webchat.registerAnalyticsService((event: AnalyticsEvent) => {
-				if (event.type === "webchat/close-button") {
-					webchat.endSession();
+				if (event.type === "webchat/close-button" && event.payload?.hadConnection) {
+					webchat.disconnect();
 				}
 			});
 		});
 
-	it("ends the session when the header close (X) button is used", () => {
-		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
-		wireEndSessionOnCloseButton();
+	it("disconnects when the header close (X) button is used on a connected session", () => {
+		openChatScreen();
+		connectAndLatch();
+		wireDisconnectOnCloseButton();
 
 		cy.get("[data-header-close-button]").click();
 
-		cy.get("@endSession").should("have.been.calledOnce");
+		cy.get("@disconnect").should("have.been.calledOnce");
 	});
 
-	it("does NOT end the session when collapsing via the toggle button", () => {
-		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
-		wireEndSessionOnCloseButton();
+	it("does NOT disconnect when closing the home screen before any connection (event still fires)", () => {
+		const events: AnalyticsEvent[] = [];
+		// Home screen X emits webchat/close-button, but hadConnection is false with
+		// no prior connection, so the documented guard leaves it alone. Assert the
+		// event DID fire, so it is the guard — not a missing event — that suppresses
+		// the disconnect.
+		cy.visitWebchat().initMockWebchat({ settings: { homeScreen: { enabled: true } } });
+		cy.openWebchat();
+		collectEvents(events);
+		wireDisconnectOnCloseButton();
+
+		cy.get(".webchat-homescreen-close-button").click();
+
+		cy.wait(200);
+		cy.then(() => {
+			const [event] = closeButtonEventsOf(events);
+			expect(event, "close-button fired on the home screen").to.exist;
+			expect(event.payload).to.deep.equal({ connected: false, hadConnection: false });
+		});
+		cy.get("@disconnect").should("not.have.been.called");
+	});
+
+	it("DOES disconnect when closing the home screen after a prior connection", () => {
+		// hadConnection latches true on first connect and never resets, and the home
+		// screen is reachable again after connecting (the header X sets showHomeScreen
+		// true, then reopening lands back on it). A home-screen close there carries
+		// hadConnection: true, so the documented guard fires.
+		cy.visitWebchat().initMockWebchat({ settings: { homeScreen: { enabled: true } } });
+		cy.openWebchat().startConversation(); // leave the home screen into the chat
+		connectAndLatch(); // connect -> hadConnection latches true
+		cy.get("[data-header-close-button]").click(); // header X: returns to home screen + collapses
+		cy.openWebchat(); // reopen -> back on the home screen, still connected
+		wireDisconnectOnCloseButton();
+
+		cy.get(".webchat-homescreen-close-button").should("be.visible").click();
+
+		cy.get("@disconnect").should("have.been.calledOnce");
+	});
+
+	it("does NOT disconnect when collapsing via the toggle button", () => {
+		openChatScreen();
+		connectAndLatch();
+		wireDisconnectOnCloseButton();
 
 		cy.get("#webchatWindowToggleButton").click();
 
 		cy.wait(200);
-		cy.get("@endSession").should("not.have.been.called");
+		cy.get("@disconnect").should("not.have.been.called");
 	});
 
-	it("does NOT end the session when minimizing", () => {
-		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
-		wireEndSessionOnCloseButton();
+	it("does NOT disconnect when minimizing", () => {
+		openChatScreen();
+		connectAndLatch();
+		wireDisconnectOnCloseButton();
 
 		cy.get("[data-header-minimize-button]").click();
 
 		cy.wait(200);
-		cy.get("@endSession").should("not.have.been.called");
+		cy.get("@disconnect").should("not.have.been.called");
+	});
+});
+
+describe("Webchat API: disconnect()", () => {
+	it("tears down the socket connection through the client", () => {
+		openChatScreen();
+
+		cy.getWebchat().then((webchat: any) => {
+			// webchat.disconnect() dispatches DISCONNECT, which the connection
+			// middleware forwards to the socket client.
+			const clientDisconnect = cy.spy(webchat.client, "disconnect");
+			webchat.disconnect();
+			expect(clientDisconnect, "client.disconnect called once").to.have.been.calledOnce;
+		});
 	});
 });

--- a/docs/analytics-api.md
+++ b/docs/analytics-api.md
@@ -23,33 +23,43 @@ Anytime an event is being emitted within the Webchat, it will cause the passed c
 The `event` object will always have a `type` property and may have a `payload` property depending on the event.
 By checking for `event.type`, you can filter events for the ones you are interested in.
 
-If you e.g. want to end the session when the user closes the Webchat widget using the header close ("X") button, listen for the `webchat/close-button` event:
+If you want to react when the user closes the Webchat widget using a header close ("X") button, listen for the `webchat/close-button` event. A common goal is to tear down the connection when the user closes the chat — for example after the connection dropped and the user dismisses the connection-lost overlay. Use `webchat.disconnect()` for that, and use the event payload to act **only when a session was actually started** (the same close button also appears on screens shown _before_ a session connects — the home screen, the privacy notice, and the previous-conversations screen):
 
 ```javascript
 webchat.registerAnalyticsService(event => {
 	if (event.type === "webchat/close-button") {
-		webchat.endSession();
+		// `hadConnection` is true once a session has connected this visit —
+		// including after the connection dropped (e.g. the connection-lost
+		// overlay) or a home screen returned to after connecting. It is false
+		// only before the first connection, where there is nothing to disconnect.
+		if (event.payload?.hadConnection) {
+			webchat.disconnect();
+		}
 	}
 });
 ```
 
-This will end the current session and clear any messages from the session.
+Pick the action that matches your intent:
+
+- **`webchat.disconnect()`** — close the socket and halt reconnection attempts. This is usually what you want when the user closes a chat, especially after the connection was lost. It is not a permanent stop: the Webchat reconnects when the conversation resumes or connectivity is restored — see [`webchat.disconnect()`](./webchat-api.md#disconnect-the-session).
+- **`webchat.endSession()`** — switch to a fresh session and clear its messages. This **reconnects** to a new session; it does not stop the connection. Use it to reset the conversation, not to disconnect.
+- **`webchat.close()`** — only collapse the widget; the connection and any reconnection attempts keep running in the background.
 
 > [!NOTE]
-> Use `webchat/close-button` rather than `webchat/close` for this. The `webchat/close` event also fires when the user collapses the open chat with the toggle button (the chat icon in the corner of the page) and when you call `webchat.close()` or `webchat.toggle()`, so ending the session on `webchat/close` would also end it on every toggle. The `webchat/close-button` event fires **only** when a header close ("X") button is used — both the chat window header and the connection-lost (disconnect) overlay. The home screen's close button and the header minimize button emit `webchat/minimize` (never `webchat/close-button`), so they do not end the session.
+> Use `webchat/close-button` rather than `webchat/close` for this. The `webchat/close` event also fires when the user collapses the open chat with the toggle button (the chat icon in the corner of the page) and when you call `webchat.close()` or `webchat.toggle()`, so acting on `webchat/close` would also fire on every toggle. The `webchat/close-button` event fires when a header close ("X") button is used — the chat window header, the home screen, and the connection-lost (disconnect) overlay. (The home screen's X also emits `webchat/minimize`, since it minimizes rather than closing a session.) The header **minimize** button emits only `webchat/minimize`, never `webchat/close-button`. Because the close button also appears on pre-session screens, always check `event.payload.hadConnection` (as shown above) before acting.
 
 ## Webchat Events
 
-| Type                       | Payload          | Description                                                                                                                                                                                                                        |
-| -------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `webchat/open`             | -                | The webchat was opened                                                                                                                                                                                                             |
-| `webchat/close`            | -                | The webchat was closed — fires for a header close ("X") button, the toggle button, and the `webchat.close()` / `webchat.toggle()` APIs (but not for minimizing)                                                                    |
-| `webchat/close-button`     | -                | The webchat was closed via a header close ("X") button — the chat window header or the disconnect overlay. Does not fire for the toggle button, the home screen close (which minimizes), or `webchat.close()` / `webchat.toggle()` |
-| `webchat/minimize`         | -                | The webchat was minimized                                                                                                                                                                                                          |
-| `webchat/switch-session`   | `sessionId`      | The session was switched                                                                                                                                                                                                           |
-| `webchat/incoming-message` | `{ text, data }` | A message was received from Cognigy                                                                                                                                                                                                |
-| `webchat/outgoing-message` | `{ text, data }` | A message was sent to Cognigy                                                                                                                                                                                                      |
-| `plugin/messenger/action`  | `Object`         | An action was triggered from a Webchat or Messenger Template                                                                                                                                                                       |
+| Type                       | Payload                        | Description                                                                                                                                                                                                                                                                                                                                                                                      |
+| -------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `webchat/open`             | -                              | The webchat was opened                                                                                                                                                                                                                                                                                                                                                                           |
+| `webchat/close`            | -                              | The webchat was closed — fires for a header close ("X") button, the toggle button, and the `webchat.close()` / `webchat.toggle()` APIs (but not for minimizing)                                                                                                                                                                                                                                  |
+| `webchat/close-button`     | `{ connected, hadConnection }` | The webchat was closed via a header close ("X") button — the chat window header, the home screen, or the disconnect overlay. `connected` is the live socket state at close time; `hadConnection` is `true` once a session has connected this visit (and stays `true` after it drops). Does not fire for the toggle button, the header minimize button, or `webchat.close()` / `webchat.toggle()` |
+| `webchat/minimize`         | -                              | The webchat was minimized                                                                                                                                                                                                                                                                                                                                                                        |
+| `webchat/switch-session`   | `sessionId`                    | The session was switched                                                                                                                                                                                                                                                                                                                                                                         |
+| `webchat/incoming-message` | `{ text, data }`               | A message was received from Cognigy                                                                                                                                                                                                                                                                                                                                                              |
+| `webchat/outgoing-message` | `{ text, data }`               | A message was sent to Cognigy                                                                                                                                                                                                                                                                                                                                                                    |
+| `plugin/messenger/action`  | `Object`                       | An action was triggered from a Webchat or Messenger Template                                                                                                                                                                                                                                                                                                                                     |
 
 See it in action:  
 [![Edit Analytics API](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/using-the-webchat-api-ho5nk?fontsize=14&hidenavigation=1&theme=dark)

--- a/docs/webchat-api.md
+++ b/docs/webchat-api.md
@@ -56,6 +56,22 @@ document.getElementById("my-toggle-button").addEventListener("click", () => {
 
 [![Edit Opening / Closing the Webchat widget externally](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/using-the-webchat-api-o227i?fontsize=14&hidenavigation=1&theme=dark)
 
+## Disconnect the Session
+
+To close the Webchat's socket connection and stop any automatic reconnection attempts, use `webchat.disconnect()`:
+
+```javascript
+webchat.disconnect();
+```
+
+This is distinct from the other "closing" methods:
+
+- `webchat.close()` only collapses the widget — the socket connection, and any automatic reconnection attempts, keep running in the background.
+- `webchat.endSession()` switches to a fresh session and **reconnects** — it does not stop the connection.
+- `webchat.disconnect()` closes the socket and cancels in-flight reconnection attempts.
+
+`disconnect()` is not a permanent stop: the Webchat establishes a new connection again when the conversation resumes (the user sends a message or returns to the chat screen) or when connectivity is restored (the browser tab becomes visible again or the network comes back online).
+
 ## Send Messages
 
 You can use the Webchat API to send messages from outside of the Webchat widget via `webchat.sendMessage()`.

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1006,10 +1006,20 @@ export class WebchatUI extends React.PureComponent<
 	/**
 	 * Emits the `webchat/close-button` analytics event.
 	 *
-	 * Fired only from the close ("X") button handlers — the chat window header
-	 * (`handleCloseAndReset`) and the disconnect overlay (`handleClose`). It is
-	 * NOT emitted for the toggle button, the home-screen close (which minimizes),
-	 * or the programmatic `webchat.close()` / `webchat.toggle()` APIs.
+	 * Fired from every close ("X") button handler — the chat window header
+	 * (`handleCloseAndReset`), the disconnect overlay (`handleClose`) and the home
+	 * screen (`handleHomeScreenClose`). It is NOT emitted for the toggle button,
+	 * the header minimize button, or the programmatic `webchat.close()` /
+	 * `webchat.toggle()` APIs.
+	 *
+	 * The payload carries the connection status at close time so integrations can
+	 * decide whether acting on the close applies: `connected` is the live socket
+	 * state, and `hadConnection` is `true` once a session has connected this visit
+	 * (and stays `true` after it drops — e.g. the disconnect overlay, or a home
+	 * screen returned to after connecting). It is `false` only before the first
+	 * connection (a first-visit home screen, the privacy notice, or the
+	 * previous-conversations screen), so a documented handler keyed on it leaves
+	 * those closes alone.
 	 *
 	 * This lives in the component rather than the redux analytics middleware
 	 * (where `webchat/open|close|minimize` are emitted) on purpose: the store only
@@ -1017,7 +1027,10 @@ export class WebchatUI extends React.PureComponent<
 	 * the close, so the originating interaction is only known here.
 	 */
 	emitCloseButtonAnalytics = () => {
-		this.props.onEmitAnalytics("webchat/close-button");
+		this.props.onEmitAnalytics("webchat/close-button", {
+			connected: this.props.connected,
+			hadConnection: this.state.hadConnection,
+		});
 	};
 
 	render() {
@@ -1394,6 +1407,18 @@ export class WebchatUI extends React.PureComponent<
 			this.chatToggleButtonRef?.current?.focus?.();
 		};
 
+		const handleHomeScreenClose = () => {
+			// The home screen's close ("X") minimizes rather than closing an active
+			// session, but it is still a header close button, so it emits
+			// "webchat/close-button" for parity with the chat window header and the
+			// disconnect overlay. Its payload's `hadConnection` is false on a
+			// first-visit home screen (nothing to act on) but true if the user
+			// already connected and returned here — so a documented handler keyed on
+			// `hadConnection` acts only when a session was actually started.
+			handleOnMinimize();
+			this.emitCloseButtonAnalytics();
+		};
+
 		const handleOnGoBack = () => {
 			if (!showChatOptionsScreen && !showRatingScreen) {
 				onSetShowPrevConversations(false);
@@ -1627,7 +1652,7 @@ export class WebchatUI extends React.PureComponent<
 							onSetShowHomeScreen={onSetShowHomeScreen}
 							onStartConversation={this.handleStartConversation}
 							onSetShowPrevConversations={onSetShowPrevConversations}
-							onClose={handleOnMinimize}
+							onClose={handleHomeScreenClose}
 							config={config}
 							onEmitAnalytics={onEmitAnalytics}
 							onSendActionButtonMessage={this.handleSendActionButtonMessage}

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -15,7 +15,7 @@ import {
 	setShowChatOptionsScreen,
 } from "../store/ui/ui-reducer";
 import { loadConfig } from "../store/config/config-middleware";
-import { connect } from "../store/connection/connection-middleware";
+import { connect, disconnect } from "../store/connection/connection-middleware";
 import { EventEmitter } from "events";
 import { SocketClient } from "@cognigy/socket-client";
 import { getEndpointBaseUrl, getEndpointUrlToken } from "../helper/endpoint";
@@ -101,6 +101,22 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 	// component API (for usage via ref)
 	connect = async () => {
 		this.store.dispatch(connect());
+	};
+
+	/**
+	 * Closes the socket connection and cancels any in-flight automatic
+	 * reconnection attempts.
+	 *
+	 * Unlike `close()` (which only collapses the widget, leaving the socket and
+	 * its reconnection loop running) and `endSession()` (which switches to a
+	 * fresh session and immediately reconnects), this leaves the Webchat
+	 * disconnected. A new connection is established again when the conversation
+	 * resumes (a message is sent or the chat screen is shown) or when
+	 * connectivity is restored (the tab becomes visible or the network comes back
+	 * online).
+	 */
+	disconnect = () => {
+		this.store.dispatch(disconnect());
 	};
 
 	sendMessage: MessageSender = (text, data, options) => {

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -15,7 +15,10 @@ import {
 	setShowChatOptionsScreen,
 } from "../store/ui/ui-reducer";
 import { loadConfig } from "../store/config/config-middleware";
-import { connect, disconnect } from "../store/connection/connection-middleware";
+import {
+	connect as connectAction,
+	disconnect as disconnectAction,
+} from "../store/connection/connection-middleware";
 import { EventEmitter } from "events";
 import { SocketClient } from "@cognigy/socket-client";
 import { getEndpointBaseUrl, getEndpointUrlToken } from "../helper/endpoint";
@@ -100,7 +103,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 
 	// component API (for usage via ref)
 	connect = async () => {
-		this.store.dispatch(connect());
+		this.store.dispatch(connectAction());
 	};
 
 	/**
@@ -116,7 +119,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 	 * online).
 	 */
 	disconnect = () => {
-		this.store.dispatch(disconnect());
+		this.store.dispatch(disconnectAction());
 	};
 
 	sendMessage: MessageSender = (text, data, options) => {


### PR DESCRIPTION
Resolves **[AB#142965](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/142965)** — _Webchat v3: Improve webchat/close-button event emitting_.

Instead of gating the `webchat/close-button` event on connection status (the originally proposed fix, which is orthogonal to emission), this gives integrations the connection status in the event payload plus a real API to disconnect, so they can decide what to do on close.

# Success criteria

- Registering an analytics service and closing via a header **X** yields a `webchat/close-button` event whose payload is `{ connected, hadConnection }`.
- `hadConnection` is `false` before the first connection (first-visit home screen, privacy notice, previous-conversations) and `true` once a session has connected this visit — and stays `true` after the connection drops (disconnect overlay) or when returning to the home screen after connecting.
- The **home screen** close button now emits `webchat/close-button` (in addition to `webchat/minimize`) — Problem 1 in the ticket.
- The header **minimize** button, the toggle button (FAB), and `webchat.close()` / `webchat.toggle()` do **not** emit `webchat/close-button`.
- A new public `webchat.disconnect()` closes the socket and cancels in-flight reconnection attempts (it is not a permanent stop — the widget reconnects on resume/visibility/network).
- Docs recommend the correct action for the "user closed the chat" case: `disconnect()` (gated on `hadConnection`), and clearly distinguish it from `endSession()` (which reconnects) and `close()` (which only collapses).

# How to test

1. `npm run build`, then serve `dist/` (e.g. `npm run cypress:serve`).
2. Automated: `npx cypress run --browser chrome --spec cypress/e2e/closeButtonAnalytics.cy.ts` — 17 specs cover emission rules, payload values (connected / disconnect-overlay / never-connected), the home-screen emission, the disconnect-on-close integration, and `webchat.disconnect()`.
3. Manual: embed the widget, `webchat.registerAnalyticsService(e => console.log(e.type, e.payload))`, and confirm:
   - Close the chat header **X** while connected → `webchat/close-button` with `{ connected: true, hadConnection: true }`.
   - Drop the connection (connection-lost overlay) and close it → `{ connected: false, hadConnection: true }`.
   - Close the **X** on a first-visit home screen → `{ connected: false, hadConnection: false }` (plus `webchat/minimize`).
   - Wire `if (e.type==="webchat/close-button" && e.payload?.hadConnection) webchat.disconnect()` and confirm the socket disconnects only when a session existed.

# Security

- [x] No security implications

_No new inputs, auth/access changes, data exposure, XSS surface, or external I/O. The added payload fields are two booleans derived from existing internal state; `webchat.disconnect()` only tears down the existing socket._

# Accessibility (WCAG 2.2 AA)

- [x] `npm run lint:a11y` passes
- [x] No accessibility implications (non-UI change)

_Purely behavioral: an analytics event payload gains two fields, the home-screen close button’s existing `onClick` additionally emits an analytics event, and a public method is added. No markup, ARIA, focus, contrast, or target-size changes — so no new `cy.checkA11yCompliance()` surface._

# Additional considerations

- [ ] This PR might have performance implications

**Behavior change (please note for the changelog):** `webchat/close-button` now also fires from the **home screen** close button, and its payload changed from `undefined` to `{ connected, hadConnection }`. An integration that copied the previously documented **unconditional** handler (`if (type==="webchat/close-button") webchat.endSession()`) will now have it fire on the home-screen close too. The updated docs recommend guarding on `event.payload.hadConnection`.

# Documentation Considerations

- `docs/analytics-api.md` — `webchat/close-button` payload, the disconnect-on-close example, and the disconnect vs endSession vs close guidance.
- `docs/webchat-api.md` — new "Disconnect the Session" section for `webchat.disconnect()`.
