### PR TITLE
Release/3.47.0

### DIFF
--- a/OSS_LICENSES.txt
+++ b/OSS_LICENSES.txt
@@ -1,4 +1,4 @@
-Created on 02-07-2026 at 14:08:29
+Created on 10-07-2026 at 19:18:11
 
 {
   "@babel/code-frame@7.29.0": {
@@ -157,7 +157,7 @@ Created on 02-07-2026 at 14:08:29
     "licenseFile": "node_modules/@cognigy/chat-components/node_modules/@braintree/sanitize-url/LICENSE",
     "copyright": "Copyright (c) 2017 Braintree"
   },
-  "@cognigy/chat-components@0.76.0": {
+  "@cognigy/chat-components@0.77.0": {
     "licenses": "MIT*",
     "repository": "https://github.com/Cognigy/chat-components",
     "licenseFile": "node_modules/@cognigy/chat-components/LICENSE",
@@ -170,7 +170,7 @@ Created on 02-07-2026 at 14:08:29
     "licenseFile": "node_modules/@cognigy/socket-client/LICENSE",
     "copyright": "Copyright (c) 2019 Cognigy GmbH"
   },
-  "@cognigy/webchat@3.46.0": {
+  "@cognigy/webchat@3.47.0": {
     "licenses": "MIT*",
     "repository": "https://github.com/Cognigy/Webchat",
     "publisher": "Cognigy GmbH",
@@ -1053,7 +1053,7 @@ Created on 02-07-2026 at 14:08:29
     "licenseFile": "node_modules/dom-helpers/LICENSE",
     "copyright": "Copyright (c) 2015 Jason Quense"
   },
-  "dompurify@3.4.0": {
+  "dompurify@3.4.11": {
     "licenses": "(MPL-2.0 OR Apache-2.0)",
     "repository": "https://github.com/cure53/DOMPurify",
     "publisher": "Dr.-Ing. Mario Heiderich, Cure53",

--- a/cypress/e2e/homeScreen.cy.ts
+++ b/cypress/e2e/homeScreen.cy.ts
@@ -331,10 +331,12 @@ describe("Home Screen", () => {
 			},
 		});
 		cy.openWebchat();
+		// "not.have.attr" must come last: it changes the yielded subject
+		// to the attribute value (undefined), breaking chained assertions.
 		cy.get(".webchat-homescreen-button")
-			.should("not.have.attr", "aria-label")
 			.should("contain.text", "Web URL starter")
-			.should("contain.text", "Opens in new tab");
+			.should("contain.text", "Opens in new tab")
+			.should("not.have.attr", "aria-label");
 	});
 
 	it("has phone number button with tel link when configured", () => {

--- a/cypress/e2e/homeScreen.cy.ts
+++ b/cypress/e2e/homeScreen.cy.ts
@@ -309,7 +309,9 @@ describe("Home Screen", () => {
 		);
 	});
 
-	it("has web url button with correct aria-label when configured", () => {
+	// As of @cognigy/chat-components 0.77.0 (AB#105550), action buttons have no aria-label;
+	// the accessible name is formed from DOM content (title + sr-only new-tab hint).
+	it("has web url button with sr-only new-tab hint when configured", () => {
 		cy.initMockWebchat({
 			settings: {
 				homeScreen: {
@@ -329,11 +331,10 @@ describe("Home Screen", () => {
 			},
 		});
 		cy.openWebchat();
-		cy.get(".webchat-homescreen-button").should(
-			"have.attr",
-			"aria-label",
-			"Web URL starter. Opens in new tab",
-		);
+		cy.get(".webchat-homescreen-button")
+			.should("not.have.attr", "aria-label")
+			.should("contain.text", "Web URL starter")
+			.should("contain.text", "Opens in new tab");
 	});
 
 	it("has phone number button with tel link when configured", () => {

--- a/cypress/e2e/messages/buttons.cy.ts
+++ b/cypress/e2e/messages/buttons.cy.ts
@@ -59,7 +59,7 @@ describe("Message with Buttons", () => {
 	it("buttons in group should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("buttons", () => {
 			cy.wrap([1, 2, 3, 4]).each(number => {
-				cy.contains(`foobar005b${number}`)
+				cy.contains(".webchat-buttons-template-button", `foobar005b${number}`)
 					.should("not.have.attr", "aria-label")
 					.should("contain.text", `${number} of 4: foobar005b${number}`);
 			});

--- a/cypress/e2e/messages/buttons.cy.ts
+++ b/cypress/e2e/messages/buttons.cy.ts
@@ -59,9 +59,11 @@ describe("Message with Buttons", () => {
 	it("buttons in group should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("buttons", () => {
 			cy.wrap([1, 2, 3, 4]).each(number => {
+				// "not.have.attr" must come last: it changes the yielded subject
+				// to the attribute value (undefined), breaking chained assertions.
 				cy.contains(".webchat-buttons-template-button", `foobar005b${number}`)
-					.should("not.have.attr", "aria-label")
-					.should("contain.text", `${number} of 4: foobar005b${number}`);
+					.should("contain.text", `${number} of 4: foobar005b${number}`)
+					.should("not.have.attr", "aria-label");
 			});
 		});
 	});

--- a/cypress/e2e/messages/buttons.cy.ts
+++ b/cypress/e2e/messages/buttons.cy.ts
@@ -54,19 +54,21 @@ describe("Message with Buttons", () => {
 		});
 	});
 
-	it("buttons in group should have 'aria-label' attribute with button position and name", () => {
+	// As of @cognigy/chat-components 0.77.0 (AB#105550), action buttons have no aria-label;
+	// the accessible name is formed from DOM content (sr-only position text + button title).
+	it("buttons in group should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("buttons", () => {
 			cy.wrap([1, 2, 3, 4]).each(number => {
 				cy.contains(`foobar005b${number}`)
-					.invoke("attr", "aria-label")
-					.should("contain", `${number} of 4: foobar005b${number}`);
+					.should("not.have.attr", "aria-label")
+					.should("contain.text", `${number} of 4: foobar005b${number}`);
 			});
 		});
 	});
 
 	it("phone number button should be an anchor element with 'href' attribute", () => {
 		cy.withMessageFixture("buttons", () => {
-			cy.get('a[aria-label="4 of 4: foobar005b4"]')
+			cy.contains("a", "foobar005b4")
 				.invoke("attr", "href")
 				.should("contain", `tel:000111222`);
 		});

--- a/cypress/e2e/messages/gallery.cy.ts
+++ b/cypress/e2e/messages/gallery.cy.ts
@@ -110,12 +110,14 @@ describe("Message with Gallery", () => {
 		});
 	});
 
-	it("gallery buttons should have 'aria-label' attribute with button position and name", () => {
+	// As of @cognigy/chat-components 0.77.0 (AB#105550), action buttons have no aria-label;
+	// the accessible name is formed from DOM content (sr-only position text + button title).
+	it("gallery buttons should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("gallery", () => {
 			cy.wrap([1, 2, 3, 4]).each(number => {
 				cy.contains(`foobar004g1b${number}`)
-					.invoke("attr", "aria-label")
-					.should("contain", `${number} of 4: foobar004g1b${number}`);
+					.should("not.have.attr", "aria-label")
+					.should("contain.text", `${number} of 4: foobar004g1b${number}`);
 			});
 		});
 	});

--- a/cypress/e2e/messages/gallery.cy.ts
+++ b/cypress/e2e/messages/gallery.cy.ts
@@ -115,9 +115,11 @@ describe("Message with Gallery", () => {
 	it("gallery buttons should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("gallery", () => {
 			cy.wrap([1, 2, 3, 4]).each(number => {
+				// "not.have.attr" must come last: it changes the yielded subject
+				// to the attribute value (undefined), breaking chained assertions.
 				cy.contains(".webchat-carousel-template-button", `foobar004g1b${number}`)
-					.should("not.have.attr", "aria-label")
-					.should("contain.text", `${number} of 4: foobar004g1b${number}`);
+					.should("contain.text", `${number} of 4: foobar004g1b${number}`)
+					.should("not.have.attr", "aria-label");
 			});
 		});
 	});

--- a/cypress/e2e/messages/gallery.cy.ts
+++ b/cypress/e2e/messages/gallery.cy.ts
@@ -115,7 +115,7 @@ describe("Message with Gallery", () => {
 	it("gallery buttons should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("gallery", () => {
 			cy.wrap([1, 2, 3, 4]).each(number => {
-				cy.contains(`foobar004g1b${number}`)
+				cy.contains(".webchat-carousel-template-button", `foobar004g1b${number}`)
 					.should("not.have.attr", "aria-label")
 					.should("contain.text", `${number} of 4: foobar004g1b${number}`);
 			});

--- a/cypress/e2e/messages/quickReplies.cy.ts
+++ b/cypress/e2e/messages/quickReplies.cy.ts
@@ -63,14 +63,16 @@ describe("Message with Quick Replies", () => {
 		});
 	});
 
-	it("quick reply button should have 'aria-label' attribute with button position and name", () => {
+	// As of @cognigy/chat-components 0.77.0 (AB#105550), action buttons have no aria-label;
+	// the accessible name is formed from DOM content (sr-only position text + button title).
+	it("quick reply button should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("quick-replies", () => {
 			cy.contains("foobar003qr01")
-				.invoke("attr", "aria-label")
-				.should("contain", "1 of 2: foobar003qr01");
+				.should("not.have.attr", "aria-label")
+				.should("contain.text", "1 of 2: foobar003qr01");
 			cy.contains("foobar003qr02")
-				.invoke("attr", "aria-label")
-				.should("contain", "2 of 2: foobar003qr02");
+				.should("not.have.attr", "aria-label")
+				.should("contain.text", "2 of 2: foobar003qr02");
 		});
 	});
 });

--- a/cypress/e2e/messages/quickReplies.cy.ts
+++ b/cypress/e2e/messages/quickReplies.cy.ts
@@ -67,12 +67,14 @@ describe("Message with Quick Replies", () => {
 	// the accessible name is formed from DOM content (sr-only position text + button title).
 	it("quick reply button should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("quick-replies", () => {
+			// "not.have.attr" must come last: it changes the yielded subject
+			// to the attribute value (undefined), breaking chained assertions.
 			cy.contains(".webchat-quick-reply-template-button", "foobar003qr01")
-				.should("not.have.attr", "aria-label")
-				.should("contain.text", "1 of 2: foobar003qr01");
+				.should("contain.text", "1 of 2: foobar003qr01")
+				.should("not.have.attr", "aria-label");
 			cy.contains(".webchat-quick-reply-template-button", "foobar003qr02")
-				.should("not.have.attr", "aria-label")
-				.should("contain.text", "2 of 2: foobar003qr02");
+				.should("contain.text", "2 of 2: foobar003qr02")
+				.should("not.have.attr", "aria-label");
 		});
 	});
 });

--- a/cypress/e2e/messages/quickReplies.cy.ts
+++ b/cypress/e2e/messages/quickReplies.cy.ts
@@ -67,10 +67,10 @@ describe("Message with Quick Replies", () => {
 	// the accessible name is formed from DOM content (sr-only position text + button title).
 	it("quick reply button should have sr-only position text and no aria-label", () => {
 		cy.withMessageFixture("quick-replies", () => {
-			cy.contains("foobar003qr01")
+			cy.contains(".webchat-quick-reply-template-button", "foobar003qr01")
 				.should("not.have.attr", "aria-label")
 				.should("contain.text", "1 of 2: foobar003qr01");
-			cy.contains("foobar003qr02")
+			cy.contains(".webchat-quick-reply-template-button", "foobar003qr02")
 				.should("not.have.attr", "aria-label")
 				.should("contain.text", "2 of 2: foobar003qr02");
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",
-				"@cognigy/chat-components": "0.76.0",
+				"@cognigy/chat-components": "0.77.0",
 				"@cognigy/socket-client": "5.0.0-beta.26",
 				"@emotion/cache": "^10.0.29",
 				"@emotion/react": "^11.13.0",
@@ -1905,9 +1905,9 @@
 			}
 		},
 		"node_modules/@cognigy/chat-components": {
-			"version": "0.76.0",
-			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.76.0.tgz",
-			"integrity": "sha512-9d5Hgqc3fEmG1ABuioL714UoyYsEt1nqaqKPQHMvrLOe6nST6ZD2eHTIl2ggKcE91cBLnoyi/8lakwSTOIt8Kw==",
+			"version": "0.77.0",
+			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.77.0.tgz",
+			"integrity": "sha512-baO1XdO28g7JeSTWfQYyOoVMZwAVrApUAUVXF9i89qOs1EzwQ/YEZpZP8AtKgp7B9WpEt6ayPieQ//+h6GhgFA==",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@fontsource/figtree": "5.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.46.0",
+	"version": "3.47.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/webchat",
-			"version": "3.46.0",
+			"version": "3.47.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.46.0",
+	"version": "3.47.0",
 	"description": "Webchat for Cognigy.AI",
 	"author": "Cognigy GmbH <info@cognigy.com>",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"dependencies": {
 		"@braintree/sanitize-url": "^6.0.0",
-		"@cognigy/chat-components": "0.76.0",
+		"@cognigy/chat-components": "0.77.0",
 		"@cognigy/socket-client": "5.0.0-beta.26",
 		"@emotion/cache": "^10.0.29",
 		"@emotion/react": "^11.13.0",


### PR DESCRIPTION
## Release 3.47.0

### Dependency updates
- **@cognigy/chat-components 0.76.0 → 0.77.0** ([release notes](https://github.com/Cognigy/chat-components/releases/tag/v0.77.0)):
  - **ActionButton a11y**: `aria-label` removed; the accessible name is now formed from the button's DOM content — sr-only position text ("N of M: ") and sr-only new-tab hint ([AB#105550](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/105550), Cognigy/chat-components#256)
  - **Avatar**: primary-color background now scoped to bundled default avatars only; custom avatar images stay transparent ([AB#90506](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/90506), Cognigy/chat-components#255)
  - WCAG 2.2 AA governance gates added upstream (test infra only, no runtime change) ([AB#144248](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/144248), Cognigy/chat-components#257)

### Test adaptations
- E2E specs that pinned the old ActionButton `aria-label` output updated to assert the new sr-only DOM content instead (`buttons.cy.ts`, `quickReplies.cy.ts`, `gallery.cy.ts`, `homeScreen.cy.ts`)

### Also shipping since 3.46.0
- Analytics: connection status on `webchat/close-button` event + `webchat.disconnect()` API ([AB#142965](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/142965), #292)
- dompurify package update (#291)

### Release chores
- `npm version minor` → 3.47.0
- `OSS_LICENSES.txt` regenerated for 3.47.0 (self-reference stamps 3.47.0, chat-components 0.77.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)