### PR TITLE
AB#146290) fix(security): disableHtmlInput neutralizes entity-encoded tags to inert text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ cypress/downloads
 stats.json
 codeql-db
 codeql-results-dist.sarif
+
+# Superpowers brainstorming/planning docs (local working files, not committed)
+docs/superpowers/

--- a/cypress/e2e/disableHtmlInput.cy.ts
+++ b/cypress/e2e/disableHtmlInput.cy.ts
@@ -32,6 +32,15 @@ describe("disableHtmlInput", () => {
 		cy.get(".webchat-chat-history").contains("onerror=alert(1)");
 	});
 
+	it("neutralizes a doubly entity-encoded <img> payload to inert text", () => {
+		init();
+		typeAndSend("&amp;#60;img src=x onerror=alert(1)&amp;#62;");
+
+		// Nested encoding must never reconstruct a live element downstream
+		cy.get("[data-cognigy-webchat-root]").find('img[src="x"]').should("not.exist");
+		cy.get(".webchat-chat-history").contains("onerror=alert(1)");
+	});
+
 	it("still strips a real tag down to its text (regression guard)", () => {
 		init();
 		typeAndSend("<b>bold</b>");

--- a/cypress/e2e/disableHtmlInput.cy.ts
+++ b/cypress/e2e/disableHtmlInput.cy.ts
@@ -1,0 +1,55 @@
+describe("disableHtmlInput", () => {
+	const init = () =>
+		cy
+			.visitWebchat()
+			.initMockWebchat({
+				settings: {
+					widgetSettings: {
+						disableHtmlInput: true,
+					},
+				},
+			})
+			.openWebchat()
+			.startConversation();
+
+	const typeAndSend = (value: string) => {
+		cy.get(".webchat-input-message-label")
+			.contains("label", "Type something here…")
+			.invoke("attr", "for")
+			.then(inputId => {
+				cy.get(`#${inputId}`).type(value, { parseSpecialCharSequences: false });
+			});
+		cy.get('[aria-label="Send message"]').click();
+	};
+
+	it("renders an entity-encoded <img> payload as inert text, not a live element", () => {
+		init();
+		typeAndSend("&#60;img src=x onerror=alert(1)&#62;");
+
+		// No live element is created anywhere in the widget from the payload
+		cy.get("[data-cognigy-webchat-root]").find('img[src="x"]').should("not.exist");
+		// The payload is shown as literal, inert text in the history
+		cy.get(".webchat-chat-history").contains("onerror=alert(1)");
+	});
+
+	it("still strips a real tag down to its text (regression guard)", () => {
+		init();
+		typeAndSend("<b>bold</b>");
+		cy.get(".webchat-chat-history").contains("bold");
+		cy.get("[data-cognigy-webchat-root]").find("b").should("not.exist");
+	});
+
+	it("does not double-encode plain ampersands", () => {
+		init();
+		typeAndSend("hello & goodbye");
+		cy.get(".webchat-chat-history").contains("hello & goodbye");
+	});
+
+	describe("Accessibility (WCAG 2.2 AA)", () => {
+		it("input surface has no a11y violations after sending", () => {
+			init();
+			typeAndSend("<b>bold</b>");
+			cy.checkA11yCompliance("[data-cognigy-webchat-root]");
+		});
+	});
+});

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -377,7 +377,7 @@ _These settings are NOT configurable via the Endpoint Editor in Cognigy.AI_
 | ----------------------------------- | ------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | disableDefaultReplyCompatiblityMode | boolean | `false` | If set to true, the webchat will not try to look for messenger content in data.\_data.\_cognigy. This can lead to issues with structured content in Intent Default Replies. |
 | enableStrictMessengerSync | boolean | `false` | If set to true, will NOT render the message from the "Messenger" tab in the SAY node unless "Use Facebook Channel" is checked in the "Webchat" tab. |
-| disableHtmlInput | boolean | `true` | If true, strips all html tags out from the input of the user. |
+| disableHtmlInput | boolean | `true` | If true, strips all HTML tags out of the user's input; HTML-entity-encoded tags are shown as inert plain text (never rendered as live elements). |
 | disableInputAutofocus | boolean | `false` | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget. |
 | disableRenderURLsAsLinks | boolean | `false` | If true, disables the automatic replacement of URLs in message elements with clickable HTML link elements. |
 | disableTextInputSanitization | boolean | `false` | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc. |

--- a/src/webchat/helper/sanitize.ts
+++ b/src/webchat/helper/sanitize.ts
@@ -238,3 +238,13 @@ export const sanitizeHTML = (text: string) => {
 
 	return DOMPurify.sanitize(text, configToUse).toString();
 };
+
+export const stripHtmlToInertText = (text: string): string => {
+	// 1. strip tags: parse as HTML and keep only the text content
+	const stripped = new DOMParser().parseFromString(text, "text/html").body.textContent || "";
+	// 2. re-escape so <, >, & render as literal characters and can never
+	//    be reinterpreted as markup downstream (robust to nested encoding)
+	const escaper = document.createElement("div");
+	escaper.textContent = stripped;
+	return escaper.innerHTML;
+};

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -5,7 +5,7 @@ import { addMessage, addMessageEvent } from "./message-reducer";
 import { Omit } from "react-redux";
 import { setFullscreenMessage, setLastInputId } from "../ui/ui-reducer";
 import { receiveMessage, ReceiveMessageAction } from "./message-handler";
-import { sanitizeHTML } from "../../helper/sanitize";
+import { sanitizeHTML, stripHtmlToInertText } from "../../helper/sanitize";
 import { SocketClient } from "@cognigy/socket-client";
 import { IMessageEvent } from "../../../common/interfaces/event";
 import bellSound from "../../../webchat-ui/utils/bell-sound";
@@ -124,9 +124,7 @@ export const createMessageMiddleware =
 				}
 
 				if (store.getState().config.settings.widgetSettings.disableHtmlInput) {
-					text =
-						new DOMParser().parseFromString(text || "", "text/html").body.textContent ||
-						"";
+					text = stripHtmlToInertText(text || "");
 				}
 
 				// data is either a non-empty object or null


### PR DESCRIPTION
## Problem

With `widgetSettings.disableHtmlInput: true` (the default, documented as _"strips all html tags out from the input of the user"_), an HTML-entity-encoded tag payload was **decoded and rendered as a live DOM element** — the opposite of the documented behavior.

**Repro:** with `disableHtmlInput: true`, type `&#60;img src=x onerror=alert(1)&#62;` and send → a live `<img>` element appears in the DOM. `<b>bold</b>` correctly reduces to `bold`, so the bug was inconsistent.

## Root cause

In the SEND_MESSAGE middleware, two transforms run in sequence:

1. `sanitizeHTML` (DOMPurify) — **escapes** `<`/`>` to entities.
2. `disableHtmlInput` — used `DOMParser().body.textContent`, which **decodes** entities.

Step 2 undoes step 1: the entity-encoded payload gets decoded back into a raw `<img>` tag string, sent/stored, and turned into a live element by the output renderer (where `img` is an allowed tag).

## Fix

Extract `stripHtmlToInertText`: strip tags, then **re-escape** (`<`/`>`/`&`) so the result is inert and can never be reinterpreted as markup — robust to nested encoding and independent of downstream output-sanitization config.

| Input | Result |
|-------|--------|
| `&#60;img src=x onerror=alert(1)&#62;` | inert text — **no live element** |
| `<b>bold</b>` | `bold` (unchanged) |
| `hello & goodbye` | `hello & goodbye` (no double-encoding) |

## Testing

- Go to the deployed webchat app
- Start conversation
- Send the `&#60;img src=x onerror=alert(1)&#62;` as message
- Observe the message is rendered as inert plain text without any broken dom
- Also send `<b>bold</b>` as messages
- Observe the text is rendered as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)