### PR TITLE
Release/3.49.0

### DIFF
--- a/OSS_LICENSES.txt
+++ b/OSS_LICENSES.txt
@@ -1,4 +1,4 @@
-Created on 27-07-2026 at 12:01:49
+Created on 07-08-2026 at 13:03:04
 
 {
   "@babel/code-frame@7.29.0": {
@@ -170,7 +170,7 @@ Created on 27-07-2026 at 12:01:49
     "licenseFile": "node_modules/@cognigy/socket-client/LICENSE",
     "copyright": "Copyright (c) 2019 Cognigy GmbH"
   },
-  "@cognigy/webchat@3.48.0": {
+  "@cognigy/webchat@3.49.0": {
     "licenses": "MIT*",
     "repository": "https://github.com/Cognigy/Webchat",
     "publisher": "Cognigy GmbH",
@@ -689,7 +689,7 @@ Created on 27-07-2026 at 12:01:49
     "licenseFile": "node_modules/autolinker/LICENSE",
     "copyright": "Copyright (c) 2014 Gregory Jacobs (http://greg-jacobs.com)"
   },
-  "axios@1.18.1": {
+  "axios@1.19.0": {
     "licenses": "MIT",
     "repository": "https://github.com/axios/axios",
     "publisher": "Matt Zabriskie",
@@ -1179,13 +1179,6 @@ Created on 27-07-2026 at 12:01:49
     "licenseFile": "node_modules/estree-util-is-identifier-name/license",
     "copyright": "Copyright (c) 2020 Titus Wormer <tituswormer@gmail.com>"
   },
-  "exenv@1.2.2": {
-    "licenses": "BSD-3-Clause",
-    "repository": "https://github.com/JedWatson/exenv",
-    "publisher": "Jed Watson",
-    "licenseFile": "node_modules/exenv/LICENSE",
-    "copyright": "Copyright (c) 2013-2015, Facebook, Inc.. All rights reserved."
-  },
   "extend@3.0.2": {
     "licenses": "MIT",
     "repository": "https://github.com/justmoon/node-extend",
@@ -1219,7 +1212,7 @@ Created on 27-07-2026 at 12:01:49
     "licenseFile": "node_modules/follow-redirects/LICENSE",
     "copyright": "Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh"
   },
-  "form-data@4.0.5": {
+  "form-data@4.0.6": {
     "licenses": "MIT",
     "repository": "https://github.com/form-data/form-data",
     "publisher": "Felix Geisendörfer",
@@ -1335,7 +1328,7 @@ Created on 27-07-2026 at 12:01:49
     "licenseFile": "node_modules/has-tostringtag/LICENSE",
     "copyright": "Copyright (c) 2021 Inspect JS"
   },
-  "hasown@2.0.2": {
+  "hasown@2.0.4": {
     "licenses": "MIT",
     "repository": "https://github.com/inspect-js/hasOwn",
     "publisher": "Jordan Harband",
@@ -2362,12 +2355,6 @@ Created on 27-07-2026 at 12:01:49
     "licenseFile": "node_modules/react-redux/node_modules/react-is/LICENSE",
     "copyright": "Copyright (c) Facebook, Inc. and its affiliates."
   },
-  "react-lifecycles-compat@3.0.4": {
-    "licenses": "MIT",
-    "repository": "https://github.com/reactjs/react-lifecycles-compat",
-    "licenseFile": "node_modules/react-lifecycles-compat/LICENSE.md",
-    "copyright": "Copyright (c) 2013-present, Facebook, Inc."
-  },
   "react-markdown@9.0.3": {
     "licenses": "MIT",
     "repository": "https://github.com/remarkjs/react-markdown",
@@ -2383,12 +2370,6 @@ Created on 27-07-2026 at 12:01:49
     "email": "espen@hovlandsdal.com",
     "licenseFile": "node_modules/react-markdown/license",
     "copyright": "Copyright (c) Espen Hovlandsdal"
-  },
-  "react-modal@3.16.3": {
-    "licenses": "MIT",
-    "repository": "https://github.com/reactjs/react-modal",
-    "licenseFile": "node_modules/react-modal/LICENSE",
-    "copyright": "Copyright (c) 2017 Ryan Florence"
   },
   "react-player@2.16.0": {
     "licenses": "MIT",
@@ -3034,15 +3015,6 @@ Created on 27-07-2026 at 12:01:49
     "url": "https://wooorm.com",
     "licenseFile": "node_modules/vfile/license",
     "copyright": "Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com>"
-  },
-  "warning@4.0.3": {
-    "licenses": "MIT",
-    "repository": "https://github.com/BerkeleyTrue/warning",
-    "publisher": "Berkeley Martinez",
-    "email": "berkeley@berkeleytrue.com",
-    "url": "http://www.berkeleytrue.com",
-    "licenseFile": "node_modules/warning/LICENSE.md",
-    "copyright": "Copyright (c) 2013-present, Facebook, Inc."
   },
   "web-namespaces@2.0.1": {
     "licenses": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@emotion/serialize": "1.3.3",
 				"@emotion/styled": "^11.13.0",
 				"@reduxjs/toolkit": "^2.2.7",
-				"axios": "1.18.1",
+				"axios": "1.19.0",
 				"classnames": "2.5.1",
 				"dompurify": "3.4.11",
 				"license-checker": "25.0.1",
@@ -5717,13 +5717,13 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+			"integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.16.0",
-				"form-data": "^4.0.5",
+				"form-data": "^4.0.6",
 				"https-proxy-agent": "^5.0.1",
 				"proxy-from-env": "^2.1.0"
 			}
@@ -8994,16 +8994,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -9509,9 +9509,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.48.0",
+	"version": "3.49.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/webchat",
-			"version": "3.48.0",
+			"version": "3.49.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@emotion/serialize": "1.3.3",
 		"@emotion/styled": "^11.13.0",
 		"@reduxjs/toolkit": "^2.2.7",
-		"axios": "1.18.1",
+		"axios": "1.19.0",
 		"classnames": "2.5.1",
 		"dompurify": "3.4.11",
 		"license-checker": "25.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.48.0",
+	"version": "3.49.0",
 	"description": "Webchat for Cognigy.AI",
 	"author": "Cognigy GmbH <info@cognigy.com>",
 	"contributors": [


### PR DESCRIPTION
Release 3.49.0 — an accessibility release: the four WCAG 2.2 AA fixes merged since 3.48.0, plus the routine `axios` bump.

## Dependency updates

| Package | 3.48.0 | 3.49.0 |
| --- | --- | --- |
| `axios` | 1.18.1 | **1.19.0** |
| `@cognigy/chat-components` | 0.78.0 | unchanged (already latest) |
| `@cognigy/socket-client` | 5.0.0-beta.26 | unchanged (already latest `beta`) |

`@cognigy/chat-components` needed no upstream release this time — its `main` is level with the `v0.78.0` tag (`ahead_by=0`), so there is no merged-but-unreleased work to pull in.

`axios` is used at exactly one call site — the file-upload metadata request in `src/webchat/helper/endpoint.ts` — so the bump carries no behavior change for Webchat.

## What this release ships

All four are VPAT-epic accessibility fixes, verified with NVDA + keyboard.

- **`fix(a11y)`: status message announcement, contrast + focus order** ([#298](https://github.com/Cognigy/Webchat/pull/298), CGY-4035) — an always-mounted sr-only `NotificationsLiveRegion` mirrors react-hot-toast notifications so the "Your feedback was submitted" status is announced (SC 4.1.3); the visible toast is set to `aria-live="off"` to avoid double announcements. Default theme `green` darkened `#009918` → `#007313` (5.36:1 on `green10`, SC 1.4.3) — theme overrides are unaffected. After feedback submit from the chat options screen, focus moves to the header title instead of dropping to `document.body` (SC 2.4.3).
- **`fix(a11y)`: disconnect overlay WCAG 2.2 AA compliance** ([#297](https://github.com/Cognigy/Webchat/pull/297), CGY-3269, CGY-3271, CGY-3885) — `Modal` gains a `variant="fullscreen"` mode used by the disconnect overlay, with `aria-modal`, `aria-labelledby` on the visible "Connection lost" title, a real Tab/Shift+Tab focus trap, Esc-to-close and focus restore. The chat layout behind the overlay gets `aria-hidden` + `inert`. The close button's accessible name is now "Close chat window" (still overridable via `customTranslations.ariaLabels.closeConnectionWarning`). A persistent visually-hidden `role="status"` region announces reconnect state changes. **`react-modal` is removed as a dependency** — its `setAppElement` wiring was never set up, which is why its trap and aria-hiding never worked. One new optional translation key: `customTranslations.connection_restored` (default "Connection restored.").
- **`fix(a11y)`: previous-conversations naming + transition silencing, status live-region hardening** ([#299](https://github.com/Cognigy/Webchat/pull/299), CGY-3275, CGY-3276, CGY-34519) — each conversation item's accessible name now starts with its visible preview text (SC 2.5.3), and Space activates it alongside Enter. The back-to-home slide-out no longer announces the leaving screen (SC 1.3.2), via `aria-hidden` plus a `FreezeOnExit` wrapper; the home screen's appearance is announced instead. Plus seven hardening follow-ups on the status live region (newest-notification-wins ordering, un-clobberable `ariaProps`, timeout cleanup, a shared `SrOnlyLiveRegion` primitive).
- **`fix(a11y)`: announce the AI-agent notice once per new conversation** ([#300](https://github.com/Cognigy/Webchat/pull/300), CGY-3519) — the AI-agent notice ("You're now chatting with an AI Agent." / configured `AIAgentNoticeText`) is announced when the chat screen appears, once per brand-new conversation and always before any message announcement, from its own live region coordinated with the message region. Reopening a previous conversation or navigating away and back stays silent. Held while the disconnect overlay is open.

### Integrator-visible surface

- New optional translation key `customTranslations.connection_restored`.
- The disconnect overlay's close button name changed to "Close chat window" (overridable as before).
- Default theme token `green` is darker (`#007313`). `green`/`green10` are used nowhere else, and explicit theme overrides are untouched.
- `react-modal` is gone from the dependency tree — `OSS_LICENSES.txt` sheds its transitive entries (`exenv`, …) accordingly.

## Verification

| Gate | Result |
| --- | --- |
| `npm run build` | pass (UMD + ESM; only the expected bundle-size warnings) |
| `npm run lint:a11y` | **0 errors** |
| `npm run prettier:check` | pass |
| `OSS_LICENSES.txt` self-reference | `@cognigy/webchat@3.49.0` (regenerated after the version bump) |
| Cypress E2E (Chrome / Firefox / progressive rendering) | in CI on this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
