### PR TITLE
fix(security): correct xApp cross-frame origin check (WCH-SI10-004)

### DIFF
--- a/cypress/e2e/messages/xAppsOverlay.cy.ts
+++ b/cypress/e2e/messages/xAppsOverlay.cy.ts
@@ -41,3 +41,129 @@ describe("xApps Overlay", () => {
 		});
 	});
 });
+
+/**
+ * WCH-SI10-004 — Cross-frame origin check fix.
+ *
+ * The previous check `url.startsWith(event.origin)` compared the raw URL string
+ * against the sender origin, which is semantically backwards. A domain that is a
+ * string-prefix of the configured xApp URL (e.g. "https://xapp.cognigy.a" for
+ * "https://xapp.cognigy.ai/form") could pass the check despite being a completely
+ * different origin.
+ *
+ * The fix uses `new URL(url).origin === event.origin` which compares the canonical
+ * scheme+host+port extracted from both sides — the correct cross-origin boundary.
+ *
+ * Test strategy: in the Cypress environment, postMessages sent from the test page
+ * carry origin "http://localhost:8787". Setting the xApp URL to that same origin
+ * lets us exercise the acceptance path; using a different URL origin exercises the
+ * rejection path. Both cases are observable via the closeOnSubmit behaviour.
+ */
+describe("postMessage origin validation (WCH-SI10-004)", () => {
+	beforeEach(() => {
+		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
+	});
+
+	it("closes overlay when postMessage origin exactly matches the xApp URL origin", () => {
+		// xApp URL uses localhost:8787 — the same origin as the Cypress test runner —
+		// so postMessages dispatched from the test page have a matching origin.
+		cy.receiveMessage(null, {
+			_cognigy: {
+				_app: {
+					overlaySettings: {
+						autoOpen: true,
+						closeOnSubmit: true,
+						feedbackMessage: "",
+						screenTitle: "Local xApp",
+						sendEventOnCloseIconClick: false,
+						showCloseIcon: false,
+					},
+					url: "http://localhost:8787/xapp-test",
+				},
+			},
+		});
+
+		cy.get(".webchat-header-logo-name-container").contains("Local xApp");
+
+		// postMessage from the test page — event.origin will be "http://localhost:8787".
+		// new URL("http://localhost:8787/xapp-test").origin === "http://localhost:8787" → accepted.
+		cy.window().then(win => {
+			win.postMessage({ type: "x-app-submit", success: true }, "*");
+		});
+
+		// closeOnSubmit is true and origin matched → overlay must close.
+		cy.get(".webchat-header-logo-name-container").should("not.contain", "Local xApp");
+	});
+
+	it("keeps overlay open when postMessage origin does not match the xApp URL origin", () => {
+		// xApp URL at https://example.com — the test-runner origin (http://localhost:8787)
+		// is a different origin, so the postMessage must be rejected.
+		cy.receiveMessage(null, {
+			_cognigy: {
+				_app: {
+					overlaySettings: {
+						autoOpen: true,
+						closeOnSubmit: true, // would close if origin matched
+						feedbackMessage: "",
+						screenTitle: "External xApp",
+						sendEventOnCloseIconClick: false,
+						showCloseIcon: true,
+					},
+					url: "https://example.com/xapp-form",
+				},
+			},
+		});
+
+		cy.get(".webchat-header-logo-name-container").contains("External xApp");
+
+		// postMessage from the test page — event.origin = "http://localhost:8787".
+		// new URL("https://example.com/xapp-form").origin = "https://example.com" → mismatch → rejected.
+		cy.window().then(win => {
+			win.postMessage({ type: "x-app-submit", success: true }, "*");
+		});
+
+		// Allow the (rejected) handler to run, then confirm overlay is still open.
+		cy.wait(500);
+		cy.get(".webchat-header-logo-name-container").should("contain", "External xApp");
+	});
+
+	it("ignores postMessage with a non-xapp-submit type even from a matching origin", () => {
+		cy.receiveMessage(null, {
+			_cognigy: {
+				_app: {
+					overlaySettings: {
+						autoOpen: true,
+						closeOnSubmit: true,
+						feedbackMessage: "",
+						screenTitle: "Type-check xApp",
+						sendEventOnCloseIconClick: false,
+						showCloseIcon: true,
+					},
+					url: "http://localhost:8787/xapp-test",
+				},
+			},
+		});
+
+		cy.get(".webchat-header-logo-name-container").contains("Type-check xApp");
+
+		// Origin matches but type is wrong — overlay must stay open.
+		cy.window().then(win => {
+			win.postMessage({ type: "some-other-event", payload: "data" }, "*");
+		});
+
+		cy.wait(500);
+		cy.get(".webchat-header-logo-name-container").should("contain", "Type-check xApp");
+	});
+});
+
+describe("Accessibility (WCAG 2.2 AA)", () => {
+	beforeEach(() => {
+		cy.visitWebchat().initMockWebchat().openWebchat().startConversation();
+	});
+
+	it("xApps overlay passes axe audit", () => {
+		cy.withMessageFixture("xApps-overlay-autoOpen", () => {
+			cy.checkA11yCompliance("[data-cognigy-webchat-root]");
+		});
+	});
+});

--- a/src/webchat-ui/components/functional/xapp-overlay/XAppOverlay.tsx
+++ b/src/webchat-ui/components/functional/xapp-overlay/XAppOverlay.tsx
@@ -74,7 +74,21 @@ const xAppOverlay: FC = () => {
 	};
 
 	const handleSubmit = (event: MessageEvent) => {
-		if (url.startsWith(event.origin) === false) {
+		// WCH-SI10-004: compare canonical origins, not raw URL strings.
+		// The previous url.startsWith(event.origin) check was semantically backwards —
+		// a domain that is a string-prefix of url (e.g. "https://xapp.cognigy.a" for
+		// "https://xapp.cognigy.ai/form") could pass the check despite being a different
+		// origin. new URL(url).origin extracts the canonical scheme+host+port for an
+		// exact match, which is the correct cross-origin security boundary.
+		let urlOrigin: string;
+		try {
+			urlOrigin = new URL(url).origin;
+		} catch {
+			// url is empty or not a valid absolute URL — reject all postMessages.
+			return;
+		}
+
+		if (urlOrigin !== event.origin) {
 			return;
 		}
 
@@ -104,8 +118,12 @@ const xAppOverlay: FC = () => {
 		handleClose();
 	};
 
-	// We revieve a MessageEvent from the xApp iframe when submission happens
+	// We receive a MessageEvent from the xApp iframe when submission happens.
 	// https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent
+	// url and feedbackMessage are included in deps so the handler is re-registered
+	// whenever either changes — both affect the handleSubmit closure and can change
+	// independently (e.g. a subsequent RECEIVE_MESSAGE can update overlay settings
+	// for the same URL, which would change feedbackMessage without changing url).
 	useEffect(() => {
 		function unsubscribe() {
 			window.removeEventListener("message", handleSubmit);
@@ -116,7 +134,7 @@ const xAppOverlay: FC = () => {
 		return () => {
 			unsubscribe();
 		};
-	}, [closeOnSubmit]);
+	}, [closeOnSubmit, url, feedbackMessage]);
 
 	const showHeader = screenTitle || showCloseIcon;
 

--- a/src/webchat-ui/components/functional/xapp-overlay/XAppOverlay.tsx
+++ b/src/webchat-ui/components/functional/xapp-overlay/XAppOverlay.tsx
@@ -139,7 +139,7 @@ const xAppOverlay: FC = () => {
 	const showHeader = screenTitle || showCloseIcon;
 
 	return (
-		<Root tabIndex={0} role="dialog" aria-modal="true">
+		<Root tabIndex={0} role="dialog" aria-modal="true" aria-label={screenTitle || "xApp"}>
 			{showHeader && (
 				<Header
 					title={screenTitle}
@@ -149,14 +149,15 @@ const xAppOverlay: FC = () => {
 			)}
 			<Iframe
 				src={url}
+				title={screenTitle || "xApp"}
 				allow="
-  accelerometer; ambient-light-sensor; autoplay; battery; bluetooth; camera; 
-  cross-origin-isolated; display-capture; document-domain; encrypted-media; 
-  execution-while-not-rendered; execution-while-out-of-viewport; 
-  fullscreen; gamepad; geolocation; gyroscope; hid; idle-detection; 
-  interest-cohort; local-fonts; magnetometer; microphone; midi; 
-  otp-credentials; payment; picture-in-picture; publickey-credentials-get; 
-  screen-wake-lock; serial; speaker-selection; usb; web-share; 
+  accelerometer; ambient-light-sensor; autoplay; battery; bluetooth; camera;
+  cross-origin-isolated; display-capture; document-domain; encrypted-media;
+  execution-while-not-rendered; execution-while-out-of-viewport;
+  fullscreen; gamepad; geolocation; gyroscope; hid; idle-detection;
+  interest-cohort; local-fonts; magnetometer; microphone; midi;
+  otp-credentials; payment; picture-in-picture; publickey-credentials-get;
+  screen-wake-lock; serial; speaker-selection; usb; web-share;
   xr-spatial-tracking"
 			/>
 		</Root>


### PR DESCRIPTION
## Summary

- **Finding:** WCH-SI10-004 — HIGH — Cross-frame `postMessage` origin check semantically backwards and bypassable
- **Control:** SI-10 / AC-4
- **Jira:** [CSA-97605](https://nice-ce-cxone-prod.atlassian.net/browse/CSA-97605)
- **Confluence:** [WCH-SI10-004 remediation page](https://cognigy.atlassian.net/wiki/spaces/Engineering/pages/2745073678)

### The bug

`XAppOverlay.tsx` checked cross-frame `postMessage` origins with:

`	s
if (url.startsWith(event.origin) === false) { return; }
`

This is semantically backwards — a domain that is a string-prefix of the configured URL (e.g. `https://xapp.cognigy.a` for `https://xapp.cognigy.ai/form`) passes the check despite being a different origin. A passing message can inject into the chat log or close the overlay.

### The fix

`	s
let urlOrigin: string;
try {
    urlOrigin = new URL(url).origin;
} catch {
    return; // empty or invalid url — reject
}
if (urlOrigin !== event.origin) { return; }
`

Also adds `url` to the `useEffect` dependency array to prevent a stale-closure when the xApp URL changes.

### Zero functional impact — all legitimate xApp flows unchanged.

## Test plan

- [x] New: origin match → overlay closes (`closeOnSubmit: true`)
- [x] New: origin mismatch → overlay stays open
- [x] New: wrong message type ignored even with matching origin
- [x] New: `cy.checkA11yCompliance` on xApp overlay (WCAG 2.2 AA)
- [x] All 4 pre-existing xApp overlay tests unchanged

## Changelog

### Security
- Fixed xApp `postMessage` origin check — replaced `url.startsWith(event.origin)` with `new URL(url).origin === event.origin` to close string-prefix bypass (WCH-SI10-004, SI-10/AC-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CSA-97605]: https://nice-ce-cxone-prod.atlassian.net/browse/CSA-97605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ