### PR TITLE
Release/3.50.0

### DIFF
--- a/OSS_LICENSES.txt
+++ b/OSS_LICENSES.txt
@@ -1,4 +1,4 @@
-Created on 07-08-2026 at 13:03:04
+Created on 21-08-2026 at 16:15:20
 
 {
   "@babel/code-frame@7.29.0": {
@@ -157,7 +157,7 @@ Created on 07-08-2026 at 13:03:04
     "licenseFile": "node_modules/@cognigy/chat-components/node_modules/@braintree/sanitize-url/LICENSE",
     "copyright": "Copyright (c) 2017 Braintree"
   },
-  "@cognigy/chat-components@0.78.0": {
+  "@cognigy/chat-components@0.79.0": {
     "licenses": "MIT*",
     "repository": "https://github.com/Cognigy/chat-components",
     "licenseFile": "node_modules/@cognigy/chat-components/LICENSE",
@@ -170,7 +170,7 @@ Created on 07-08-2026 at 13:03:04
     "licenseFile": "node_modules/@cognigy/socket-client/LICENSE",
     "copyright": "Copyright (c) 2019 Cognigy GmbH"
   },
-  "@cognigy/webchat@3.49.0": {
+  "@cognigy/webchat@3.50.0": {
     "licenses": "MIT*",
     "repository": "https://github.com/Cognigy/Webchat",
     "publisher": "Cognigy GmbH",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",
-				"@cognigy/chat-components": "0.78.0",
+				"@cognigy/chat-components": "0.79.0",
 				"@cognigy/socket-client": "5.0.0-beta.26",
 				"@emotion/cache": "^10.0.29",
 				"@emotion/react": "^11.13.0",
@@ -1904,9 +1904,9 @@
 			}
 		},
 		"node_modules/@cognigy/chat-components": {
-			"version": "0.78.0",
-			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.78.0.tgz",
-			"integrity": "sha512-DVyWDB/HFsMscQvciNzkn879pANkw8+dIL/tfHT60XWrWzlxHu6Q6hQ4XXz+223xTmrM1uEGrdNMPOO1KxuD1w==",
+			"version": "0.79.0",
+			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.79.0.tgz",
+			"integrity": "sha512-03RGq/dPb+ffHYBykLMs88vi4uDHkewIGEINkadhmJs7gt8QXuBbWEz4j6rC3mOobHsLQWFrOB6FmNY8fLiJ8Q==",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@fontsource/figtree": "5.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.49.0",
+	"version": "3.50.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/webchat",
-			"version": "3.49.0",
+			"version": "3.50.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"dependencies": {
 		"@braintree/sanitize-url": "^6.0.0",
-		"@cognigy/chat-components": "0.78.0",
+		"@cognigy/chat-components": "0.79.0",
 		"@cognigy/socket-client": "5.0.0-beta.26",
 		"@emotion/cache": "^10.0.29",
 		"@emotion/react": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/webchat",
-	"version": "3.49.0",
+	"version": "3.50.0",
 	"description": "Webchat for Cognigy.AI",
 	"author": "Cognigy GmbH <info@cognigy.com>",
 	"contributors": [


### PR DESCRIPTION
## Summary
- Bump `@cognigy/chat-components` from 0.78.0 to 0.79.0
- Version bump to 3.50.0 and regenerated `OSS_LICENSES.txt`

## chat-components 0.79.0 changes
- fix(datepicker): restore year stepper arrows (CSA-92602) — [chat-components#265](https://github.com/Cognigy/chat-components/pull/265). CSS-only fix restoring previously-hidden Flatpickr year stepper arrows; DOM/JS behavior unchanged.
- fix(action-button): open `web_url` buttons in a new tab on the opt-out path (CGY-34585) — [chat-components#266](https://github.com/Cognigy/chat-components/pull/266). Restores new-tab navigation for untargeted `web_url` buttons when `disableUrlButtonSanitization: true`. **Accessibility change:** the sr-only "opens in new tab" announcement now fires for opt-out consumers on this path, matching the restored behavior.

## Test plan
- [x] `npm run build` — succeeds (only expected bundle-size warnings)
- [x] `npm run lint:a11y` — 0 errors
- [x] `npm run prettier:check` — clean (aside from pre-existing, unrelated `.superpowers/` scratch files)
- [x] Full Cypress Chrome E2E suite (`npm test`) — all passing, no failures
- [x] `OSS_LICENSES.txt` self-reference confirmed as `@cognigy/webchat@3.50.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)